### PR TITLE
Make partition info pushdown and filter pushdown optional

### DIFF
--- a/src/delta_extension.cpp
+++ b/src/delta_extension.cpp
@@ -27,7 +27,7 @@ static unique_ptr<Catalog> DeltaCatalogAttach(StorageExtensionInfo *storage_info
 		if (StringUtil::Lower(option.first) == "pin_snapshot") {
 			res->use_cache = option.second.GetValue<bool>();
 		}
-	    if (StringUtil::Lower(option.first) == "pushdown_partition_info") {
+		if (StringUtil::Lower(option.first) == "pushdown_partition_info") {
 			res->pushdown_partition_info = option.second.GetValue<bool>();
 		}
 	}

--- a/src/delta_extension.cpp
+++ b/src/delta_extension.cpp
@@ -27,6 +27,9 @@ static unique_ptr<Catalog> DeltaCatalogAttach(StorageExtensionInfo *storage_info
 		if (StringUtil::Lower(option.first) == "pin_snapshot") {
 			res->use_cache = option.second.GetValue<bool>();
 		}
+	    if (StringUtil::Lower(option.first) == "pushdown_partition_info") {
+			res->pushdown_partition_info = option.second.GetValue<bool>();
+		}
 	}
 
 	res->SetDefaultTable(DEFAULT_SCHEMA, name);

--- a/src/delta_extension.cpp
+++ b/src/delta_extension.cpp
@@ -30,6 +30,10 @@ static unique_ptr<Catalog> DeltaCatalogAttach(StorageExtensionInfo *storage_info
 		if (StringUtil::Lower(option.first) == "pushdown_partition_info") {
 			res->pushdown_partition_info = option.second.GetValue<bool>();
 		}
+        if (StringUtil::Lower(option.first) == "pushdown_filters") {
+            auto str = option.second.GetValue<string>();
+            res->filter_pushdown_mode = DeltaEnumUtils::FromString(str);
+		}
 	}
 
 	res->SetDefaultTable(DEFAULT_SCHEMA, name);

--- a/src/delta_extension.cpp
+++ b/src/delta_extension.cpp
@@ -30,9 +30,9 @@ static unique_ptr<Catalog> DeltaCatalogAttach(StorageExtensionInfo *storage_info
 		if (StringUtil::Lower(option.first) == "pushdown_partition_info") {
 			res->pushdown_partition_info = option.second.GetValue<bool>();
 		}
-        if (StringUtil::Lower(option.first) == "pushdown_filters") {
-            auto str = option.second.GetValue<string>();
-            res->filter_pushdown_mode = DeltaEnumUtils::FromString(str);
+		if (StringUtil::Lower(option.first) == "pushdown_filters") {
+			auto str = option.second.GetValue<string>();
+			res->filter_pushdown_mode = DeltaEnumUtils::FromString(str);
 		}
 	}
 

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -606,23 +606,24 @@ unique_ptr<DeltaMultiFileList> DeltaMultiFileList::PushdownInternal(ClientContex
 	return filtered_list;
 }
 
-static DeltaFilterPushdownMode GetDeltaFilterPushdownMode(ClientContext &context, const MultiFileReaderOptions &options) {
-    auto res = options.custom_options.find("pushdown_filters");
-    if (res != options.custom_options.end()) {
-        auto str = res->second.GetValue<string>();
-        return DeltaEnumUtils::FromString(str);
-    }
+static DeltaFilterPushdownMode GetDeltaFilterPushdownMode(ClientContext &context,
+                                                          const MultiFileReaderOptions &options) {
+	auto res = options.custom_options.find("pushdown_filters");
+	if (res != options.custom_options.end()) {
+		auto str = res->second.GetValue<string>();
+		return DeltaEnumUtils::FromString(str);
+	}
 
-    return DEFAULT_PUSHDOWN_MODE;
+	return DEFAULT_PUSHDOWN_MODE;
 }
 unique_ptr<MultiFileList> DeltaMultiFileList::ComplexFilterPushdown(ClientContext &context,
                                                                     const MultiFileReaderOptions &options,
                                                                     MultiFilePushdownInfo &info,
                                                                     vector<unique_ptr<Expression>> &filters) {
-    auto pushdown_mode = GetDeltaFilterPushdownMode(context, options);
-    if (pushdown_mode == DeltaFilterPushdownMode::NONE || pushdown_mode == DeltaFilterPushdownMode::DYNAMIC_ONLY) {
-        return nullptr;
-    }
+	auto pushdown_mode = GetDeltaFilterPushdownMode(context, options);
+	if (pushdown_mode == DeltaFilterPushdownMode::NONE || pushdown_mode == DeltaFilterPushdownMode::DYNAMIC_ONLY) {
+		return nullptr;
+	}
 
 	FilterCombiner combiner(context);
 
@@ -751,10 +752,10 @@ unique_ptr<MultiFileList>
 DeltaMultiFileList::DynamicFilterPushdown(ClientContext &context, const MultiFileReaderOptions &options,
                                           const vector<string> &names, const vector<LogicalType> &types,
                                           const vector<column_t> &column_ids, TableFilterSet &filters) const {
-    auto pushdown_mode = GetDeltaFilterPushdownMode(context, options);
-    if (pushdown_mode == DeltaFilterPushdownMode::NONE || pushdown_mode == DeltaFilterPushdownMode::CONSTANT_ONLY) {
-        return nullptr;
-    }
+	auto pushdown_mode = GetDeltaFilterPushdownMode(context, options);
+	if (pushdown_mode == DeltaFilterPushdownMode::NONE || pushdown_mode == DeltaFilterPushdownMode::CONSTANT_ONLY) {
+		return nullptr;
+	}
 
 	if (filters.filters.empty()) {
 		return nullptr;

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -530,9 +530,9 @@ void DeltaMultiFileList::InitializeSnapshot() const {
 		    TryUnpackKernelResult(ffi::snapshot(path_slice, extern_engine.get())));
 	}
 
-    // Set version
-    auto snapshot_ref = snapshot->GetLockingRef();
-    this->version = ffi::version(snapshot_ref.GetPtr());
+	// Set version
+	auto snapshot_ref = snapshot->GetLockingRef();
+	this->version = ffi::version(snapshot_ref.GetPtr());
 
 	initialized_snapshot = true;
 }

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -530,6 +530,10 @@ void DeltaMultiFileList::InitializeSnapshot() const {
 		    TryUnpackKernelResult(ffi::snapshot(path_slice, extern_engine.get())));
 	}
 
+    // Set version
+    auto snapshot_ref = snapshot->GetLockingRef();
+    this->version = ffi::version(snapshot_ref.GetPtr());
+
 	initialized_snapshot = true;
 }
 
@@ -542,9 +546,6 @@ void DeltaMultiFileList::InitializeScan() const {
 
 	// Create GlobalState
 	global_state = ffi::get_global_scan_state(scan.get());
-
-	// Set version
-	this->version = ffi::version(snapshot_ref.GetPtr());
 
 	// Create scan data iterator
 	scan_data_iterator = TryUnpackKernelResult(ffi::kernel_scan_data_init(extern_engine.get(), scan.get()));
@@ -813,7 +814,7 @@ unique_ptr<NodeStatistics> DeltaMultiFileList::GetCardinality(ClientContext &con
 
 idx_t DeltaMultiFileList::GetVersion() {
 	unique_lock<mutex> lck(lock);
-	EnsureScanInitialized();
+	EnsureSnapshotInitialized();
 	return version;
 }
 

--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
+++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
@@ -137,28 +137,29 @@ void DeltaMultiFileReader::BindOptions(MultiFileReaderOptions &options, MultiFil
 	MultiFileReader::BindOptions(options, files, return_types, names, bind_data);
 
 	// We abuse the hive_partitioning_indexes to forward partitioning information to DuckDB
-	// TODO: we should clean up this API: hive_partitioning_indexes is confusingly named here. We should make this generic
-    auto pushdown_partition_info_setting = options.custom_options.find("pushdown_partition_info");
-    if (pushdown_partition_info_setting != options.custom_options.end() && pushdown_partition_info_setting->second.GetValue<bool>()) {
-        auto &snapshot = dynamic_cast<DeltaMultiFileList &>(files);
-        auto partitions = snapshot.GetPartitionColumns();
-        for (auto &part : partitions) {
-            idx_t hive_partitioning_index;
-            auto lookup = std::find_if(names.begin(), names.end(),
-                                       [&](const string &col_name) { return StringUtil::CIEquals(col_name, part); });
-            if (lookup != names.end()) {
-                // hive partitioning column also exists in file - override
-                auto idx = NumericCast<idx_t>(lookup - names.begin());
-                hive_partitioning_index = idx;
-            } else {
-                throw IOException("Delta Snapshot returned partition column that is not present in the schema");
-            }
-            bind_data.hive_partitioning_indexes.emplace_back(part, hive_partitioning_index);
-        }
-    }
+	// TODO: we should clean up this API: hive_partitioning_indexes is confusingly named here. We should make this
+	// generic
+	auto pushdown_partition_info_setting = options.custom_options.find("pushdown_partition_info");
+	if (pushdown_partition_info_setting != options.custom_options.end() &&
+	    pushdown_partition_info_setting->second.GetValue<bool>()) {
+		auto &snapshot = dynamic_cast<DeltaMultiFileList &>(files);
+		auto partitions = snapshot.GetPartitionColumns();
+		for (auto &part : partitions) {
+			idx_t hive_partitioning_index;
+			auto lookup = std::find_if(names.begin(), names.end(),
+			                           [&](const string &col_name) { return StringUtil::CIEquals(col_name, part); });
+			if (lookup != names.end()) {
+				// hive partitioning column also exists in file - override
+				auto idx = NumericCast<idx_t>(lookup - names.begin());
+				hive_partitioning_index = idx;
+			} else {
+				throw IOException("Delta Snapshot returned partition column that is not present in the schema");
+			}
+			bind_data.hive_partitioning_indexes.emplace_back(part, hive_partitioning_index);
+		}
+	}
 
-
-    auto demo_gen_col_opt = options.custom_options.find("delta_file_number");
+	auto demo_gen_col_opt = options.custom_options.find("delta_file_number");
 	if (demo_gen_col_opt != options.custom_options.end()) {
 		if (demo_gen_col_opt->second.GetValue<bool>()) {
 			names.push_back("delta_file_number");
@@ -466,11 +467,11 @@ bool DeltaMultiFileReader::ParseOption(const string &key, const Value &val, Mult
 		return true;
 	}
 
-    // We need to capture this one to know whether to emit
-    if (loption == "pushdown_partition_info") {
-        options.custom_options["pushdown_partition_info"] = val;
-        return true;
-    }
+	// We need to capture this one to know whether to emit
+	if (loption == "pushdown_partition_info") {
+		options.custom_options["pushdown_partition_info"] = val;
+		return true;
+	}
 
 	return MultiFileReader::ParseOption(key, val, options, context);
 }

--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
+++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
@@ -142,7 +142,7 @@ void DeltaMultiFileReader::BindOptions(MultiFileReaderOptions &options, MultiFil
 	// TODO: we should clean up this API: hive_partitioning_indexes is confusingly named here. We should make this
 	// generic
 	auto pushdown_partition_info_setting = options.custom_options.find("pushdown_partition_info");
-	if (pushdown_partition_info_setting != options.custom_options.end() &&
+	if (pushdown_partition_info_setting == options.custom_options.end() ||
 	    pushdown_partition_info_setting->second.GetValue<bool>()) {
 		auto &snapshot = dynamic_cast<DeltaMultiFileList &>(files);
 		auto partitions = snapshot.GetPartitionColumns();

--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
+++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
@@ -138,7 +138,8 @@ void DeltaMultiFileReader::BindOptions(MultiFileReaderOptions &options, MultiFil
 
 	// We abuse the hive_partitioning_indexes to forward partitioning information to DuckDB
 	// TODO: we should clean up this API: hive_partitioning_indexes is confusingly named here. We should make this generic
-    if (false) {
+    auto pushdown_partition_info_setting = options.custom_options.find("pushdown_partition_info");
+    if (pushdown_partition_info_setting != options.custom_options.end() && pushdown_partition_info_setting->second.GetValue<bool>()) {
         auto &snapshot = dynamic_cast<DeltaMultiFileList &>(files);
         auto partitions = snapshot.GetPartitionColumns();
         for (auto &part : partitions) {
@@ -464,6 +465,12 @@ bool DeltaMultiFileReader::ParseOption(const string &key, const Value &val, Mult
 		options.custom_options[loption] = val;
 		return true;
 	}
+
+    // We need to capture this one to know whether to emit
+    if (loption == "pushdown_partition_info") {
+        options.custom_options["pushdown_partition_info"] = val;
+        return true;
+    }
 
 	return MultiFileReader::ParseOption(key, val, options, context);
 }

--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
+++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
@@ -1,6 +1,8 @@
 #include "functions/delta_scan/delta_multi_file_list.hpp"
 #include "functions/delta_scan/delta_multi_file_reader.hpp"
 
+#include <functions/delta_scan/delta_scan.hpp>
+
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/execution/expression_executor.hpp"
@@ -467,9 +469,14 @@ bool DeltaMultiFileReader::ParseOption(const string &key, const Value &val, Mult
 		return true;
 	}
 
-	// We need to capture this one to know whether to emit
 	if (loption == "pushdown_partition_info") {
 		options.custom_options["pushdown_partition_info"] = val;
+		return true;
+	}
+
+    // We need to capture this one to know whether to emit
+	if (loption == "pushdown_filters") {
+		options.custom_options["pushdown_filters"] = val;
 		return true;
 	}
 

--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
+++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
@@ -474,7 +474,7 @@ bool DeltaMultiFileReader::ParseOption(const string &key, const Value &val, Mult
 		return true;
 	}
 
-    // We need to capture this one to know whether to emit
+	// We need to capture this one to know whether to emit
 	if (loption == "pushdown_filters") {
 		options.custom_options["pushdown_filters"] = val;
 		return true;

--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
+++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
@@ -137,25 +137,27 @@ void DeltaMultiFileReader::BindOptions(MultiFileReaderOptions &options, MultiFil
 	MultiFileReader::BindOptions(options, files, return_types, names, bind_data);
 
 	// We abuse the hive_partitioning_indexes to forward partitioning information to DuckDB
-	// TODO: we should clean up this API: hive_partitioning_indexes is confusingly named here. We should make this
-	// generic
-	auto &snapshot = dynamic_cast<DeltaMultiFileList &>(files);
-	auto partitions = snapshot.GetPartitionColumns();
-	for (auto &part : partitions) {
-		idx_t hive_partitioning_index;
-		auto lookup = std::find_if(names.begin(), names.end(),
-		                           [&](const string &col_name) { return StringUtil::CIEquals(col_name, part); });
-		if (lookup != names.end()) {
-			// hive partitioning column also exists in file - override
-			auto idx = NumericCast<idx_t>(lookup - names.begin());
-			hive_partitioning_index = idx;
-		} else {
-			throw IOException("Delta Snapshot returned partition column that is not present in the schema");
-		}
-		bind_data.hive_partitioning_indexes.emplace_back(part, hive_partitioning_index);
-	}
+	// TODO: we should clean up this API: hive_partitioning_indexes is confusingly named here. We should make this generic
+    if (false) {
+        auto &snapshot = dynamic_cast<DeltaMultiFileList &>(files);
+        auto partitions = snapshot.GetPartitionColumns();
+        for (auto &part : partitions) {
+            idx_t hive_partitioning_index;
+            auto lookup = std::find_if(names.begin(), names.end(),
+                                       [&](const string &col_name) { return StringUtil::CIEquals(col_name, part); });
+            if (lookup != names.end()) {
+                // hive partitioning column also exists in file - override
+                auto idx = NumericCast<idx_t>(lookup - names.begin());
+                hive_partitioning_index = idx;
+            } else {
+                throw IOException("Delta Snapshot returned partition column that is not present in the schema");
+            }
+            bind_data.hive_partitioning_indexes.emplace_back(part, hive_partitioning_index);
+        }
+    }
 
-	auto demo_gen_col_opt = options.custom_options.find("delta_file_number");
+
+    auto demo_gen_col_opt = options.custom_options.find("delta_file_number");
 	if (demo_gen_col_opt != options.custom_options.end()) {
 		if (demo_gen_col_opt->second.GetValue<bool>()) {
 			names.push_back("delta_file_number");

--- a/src/functions/delta_scan/delta_scan.cpp
+++ b/src/functions/delta_scan/delta_scan.cpp
@@ -51,6 +51,7 @@ TableFunctionSet DeltaFunctions::GetDeltaScanFunction(DatabaseInstance &instance
 
 		// Demonstration of a generated column based on information from DeltaMultiFileList
 		function.named_parameters["delta_file_number"] = LogicalType::BOOLEAN;
+		function.named_parameters["pushdown_partition_info"] = LogicalType::BOOLEAN;
 
 		function.name = "delta_scan";
 	}

--- a/src/functions/delta_scan/delta_scan.cpp
+++ b/src/functions/delta_scan/delta_scan.cpp
@@ -13,35 +13,35 @@
 namespace duckdb {
 
 DeltaFilterPushdownMode DeltaEnumUtils::FromString(const string &str) {
-    auto str_to_lower = StringUtil::Lower(str);
-    if (str_to_lower == "none") {
-        return DeltaFilterPushdownMode::NONE;
-    }
-    if (str_to_lower == "all") {
-        return DeltaFilterPushdownMode::ALL;
-    }
-    if (str_to_lower == "constant_only") {
-        return DeltaFilterPushdownMode::CONSTANT_ONLY;
-    }
-    if (str_to_lower == "dynamic_only") {
-        return DeltaFilterPushdownMode::DYNAMIC_ONLY;
-    }
-    throw InvalidInputException("Unknown Filter pushdown mode: %s", str);
+	auto str_to_lower = StringUtil::Lower(str);
+	if (str_to_lower == "none") {
+		return DeltaFilterPushdownMode::NONE;
+	}
+	if (str_to_lower == "all") {
+		return DeltaFilterPushdownMode::ALL;
+	}
+	if (str_to_lower == "constant_only") {
+		return DeltaFilterPushdownMode::CONSTANT_ONLY;
+	}
+	if (str_to_lower == "dynamic_only") {
+		return DeltaFilterPushdownMode::DYNAMIC_ONLY;
+	}
+	throw InvalidInputException("Unknown Filter pushdown mode: %s", str);
 }
 
 string DeltaEnumUtils::ToString(const DeltaFilterPushdownMode &mode) {
-    switch(mode) {
-        case DeltaFilterPushdownMode::NONE:
-            return "none";
-        case DeltaFilterPushdownMode::ALL:
-            return "all";
-        case DeltaFilterPushdownMode::DYNAMIC_ONLY:
-            return "dynamic_only";
-        case DeltaFilterPushdownMode::CONSTANT_ONLY:
-            return "constant_only";
-        default:
-            throw InvalidInputException("Unknown delta pushdown mode: %s", mode);
-    }
+	switch (mode) {
+	case DeltaFilterPushdownMode::NONE:
+		return "none";
+	case DeltaFilterPushdownMode::ALL:
+		return "all";
+	case DeltaFilterPushdownMode::DYNAMIC_ONLY:
+		return "dynamic_only";
+	case DeltaFilterPushdownMode::CONSTANT_ONLY:
+		return "constant_only";
+	default:
+		throw InvalidInputException("Unknown delta pushdown mode: %s", mode);
+	}
 }
 
 static InsertionOrderPreservingMap<string> DeltaFunctionToString(TableFunctionToStringInput &input) {
@@ -84,8 +84,8 @@ TableFunctionSet DeltaFunctions::GetDeltaScanFunction(DatabaseInstance &instance
 		// Demonstration of a generated column based on information from DeltaMultiFileList
 		function.named_parameters["delta_file_number"] = LogicalType::BOOLEAN;
 
-	    function.named_parameters["pushdown_partition_info"] = LogicalType::BOOLEAN;
-	    function.named_parameters["pushdown_filters"] = LogicalType::VARCHAR;
+		function.named_parameters["pushdown_partition_info"] = LogicalType::BOOLEAN;
+		function.named_parameters["pushdown_filters"] = LogicalType::VARCHAR;
 
 		function.name = "delta_scan";
 	}

--- a/src/functions/delta_scan/delta_scan.cpp
+++ b/src/functions/delta_scan/delta_scan.cpp
@@ -12,6 +12,38 @@
 
 namespace duckdb {
 
+DeltaFilterPushdownMode DeltaEnumUtils::FromString(const string &str) {
+    auto str_to_lower = StringUtil::Lower(str);
+    if (str_to_lower == "none") {
+        return DeltaFilterPushdownMode::NONE;
+    }
+    if (str_to_lower == "all") {
+        return DeltaFilterPushdownMode::ALL;
+    }
+    if (str_to_lower == "constant_only") {
+        return DeltaFilterPushdownMode::CONSTANT_ONLY;
+    }
+    if (str_to_lower == "dynamic_only") {
+        return DeltaFilterPushdownMode::DYNAMIC_ONLY;
+    }
+    throw InvalidInputException("Unknown Filter pushdown mode: %s", str);
+}
+
+string DeltaEnumUtils::ToString(const DeltaFilterPushdownMode &mode) {
+    switch(mode) {
+        case DeltaFilterPushdownMode::NONE:
+            return "none";
+        case DeltaFilterPushdownMode::ALL:
+            return "all";
+        case DeltaFilterPushdownMode::DYNAMIC_ONLY:
+            return "dynamic_only";
+        case DeltaFilterPushdownMode::CONSTANT_ONLY:
+            return "constant_only";
+        default:
+            throw InvalidInputException("Unknown delta pushdown mode: %s", mode);
+    }
+}
+
 static InsertionOrderPreservingMap<string> DeltaFunctionToString(TableFunctionToStringInput &input) {
 	InsertionOrderPreservingMap<string> result;
 
@@ -51,7 +83,9 @@ TableFunctionSet DeltaFunctions::GetDeltaScanFunction(DatabaseInstance &instance
 
 		// Demonstration of a generated column based on information from DeltaMultiFileList
 		function.named_parameters["delta_file_number"] = LogicalType::BOOLEAN;
-		function.named_parameters["pushdown_partition_info"] = LogicalType::BOOLEAN;
+
+	    function.named_parameters["pushdown_partition_info"] = LogicalType::BOOLEAN;
+	    function.named_parameters["pushdown_filters"] = LogicalType::VARCHAR;
 
 		function.name = "delta_scan";
 	}

--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
@@ -63,9 +63,9 @@ public:
 	FileExpandResult GetExpandResult() override;
 	idx_t GetTotalFileCount() override;
 	unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) override;
-    DeltaFileMetaData &GetMetaData(idx_t index) const;
-    idx_t GetVersion();
-    vector<string> GetPartitionColumns();
+	DeltaFileMetaData &GetMetaData(idx_t index) const;
+	idx_t GetVersion();
+	vector<string> GetPartitionColumns();
 
 protected:
 	//! Get the i-th expanded file

--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
@@ -62,11 +62,10 @@ public:
 	vector<string> GetAllFiles() override;
 	FileExpandResult GetExpandResult() override;
 	idx_t GetTotalFileCount() override;
-
 	unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) override;
-	idx_t GetVersion();
-	DeltaFileMetaData &GetMetaData(idx_t index) const;
-	vector<string> GetPartitionColumns();
+    DeltaFileMetaData &GetMetaData(idx_t index) const;
+    idx_t GetVersion();
+    vector<string> GetPartitionColumns();
 
 protected:
 	//! Get the i-th expanded file

--- a/src/include/functions/delta_scan/delta_scan.hpp
+++ b/src/include/functions/delta_scan/delta_scan.hpp
@@ -14,6 +14,20 @@
 namespace duckdb {
 class DeltaMultiFileList;
 
+enum class DeltaFilterPushdownMode : uint8_t {
+    NONE = 0,
+    ALL = 1,
+    CONSTANT_ONLY = 2,
+    DYNAMIC_ONLY = 3,
+};
+
+static constexpr DeltaFilterPushdownMode DEFAULT_PUSHDOWN_MODE = DeltaFilterPushdownMode::ALL;
+
+struct DeltaEnumUtils {
+    static DeltaFilterPushdownMode FromString(const string &str);
+    static string ToString(const DeltaFilterPushdownMode &mode);
+};
+
 struct DeltaFunctionInfo : public TableFunctionInfo {
 	shared_ptr<DeltaMultiFileList> snapshot;
 	string expected_path;

--- a/src/include/functions/delta_scan/delta_scan.hpp
+++ b/src/include/functions/delta_scan/delta_scan.hpp
@@ -15,17 +15,17 @@ namespace duckdb {
 class DeltaMultiFileList;
 
 enum class DeltaFilterPushdownMode : uint8_t {
-    NONE = 0,
-    ALL = 1,
-    CONSTANT_ONLY = 2,
-    DYNAMIC_ONLY = 3,
+	NONE = 0,
+	ALL = 1,
+	CONSTANT_ONLY = 2,
+	DYNAMIC_ONLY = 3,
 };
 
 static constexpr DeltaFilterPushdownMode DEFAULT_PUSHDOWN_MODE = DeltaFilterPushdownMode::ALL;
 
 struct DeltaEnumUtils {
-    static DeltaFilterPushdownMode FromString(const string &str);
-    static string ToString(const DeltaFilterPushdownMode &mode);
+	static DeltaFilterPushdownMode FromString(const string &str);
+	static string ToString(const DeltaFilterPushdownMode &mode);
 };
 
 struct DeltaFunctionInfo : public TableFunctionInfo {

--- a/src/include/storage/delta_catalog.hpp
+++ b/src/include/storage/delta_catalog.hpp
@@ -31,6 +31,7 @@ public:
 	string path;
 	AccessMode access_mode;
 	bool use_cache;
+	bool pushdown_partition_info;
 
 public:
 	void Initialize(bool load_builtin) override;

--- a/src/include/storage/delta_catalog.hpp
+++ b/src/include/storage/delta_catalog.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "functions/delta_scan/delta_scan.hpp"
 #include "delta_schema_entry.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/function/table_function.hpp"
@@ -32,6 +33,7 @@ public:
 	AccessMode access_mode;
 	bool use_cache;
 	bool pushdown_partition_info;
+    DeltaFilterPushdownMode filter_pushdown_mode;
 
 public:
 	void Initialize(bool load_builtin) override;

--- a/src/include/storage/delta_catalog.hpp
+++ b/src/include/storage/delta_catalog.hpp
@@ -33,7 +33,7 @@ public:
 	AccessMode access_mode;
 	bool use_cache;
 	bool pushdown_partition_info;
-    DeltaFilterPushdownMode filter_pushdown_mode;
+	DeltaFilterPushdownMode filter_pushdown_mode;
 
 public:
 	void Initialize(bool load_builtin) override;

--- a/src/storage/delta_catalog.cpp
+++ b/src/storage/delta_catalog.cpp
@@ -11,7 +11,7 @@
 namespace duckdb {
 
 DeltaCatalog::DeltaCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode)
-    : Catalog(db_p), path(path), access_mode(access_mode), use_cache(false) {
+    : Catalog(db_p), path(path), access_mode(access_mode), use_cache(false), pushdown_partition_info(false) {
 }
 
 DeltaCatalog::~DeltaCatalog() = default;

--- a/src/storage/delta_catalog.cpp
+++ b/src/storage/delta_catalog.cpp
@@ -11,7 +11,7 @@
 namespace duckdb {
 
 DeltaCatalog::DeltaCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode)
-    : Catalog(db_p), path(path), access_mode(access_mode), use_cache(false), pushdown_partition_info(false),
+    : Catalog(db_p), path(path), access_mode(access_mode), use_cache(false), pushdown_partition_info(true),
       filter_pushdown_mode(DEFAULT_PUSHDOWN_MODE) {
 }
 

--- a/src/storage/delta_catalog.cpp
+++ b/src/storage/delta_catalog.cpp
@@ -11,7 +11,8 @@
 namespace duckdb {
 
 DeltaCatalog::DeltaCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode)
-    : Catalog(db_p), path(path), access_mode(access_mode), use_cache(false), pushdown_partition_info(false), filter_pushdown_mode(DEFAULT_PUSHDOWN_MODE) {
+    : Catalog(db_p), path(path), access_mode(access_mode), use_cache(false), pushdown_partition_info(false),
+      filter_pushdown_mode(DEFAULT_PUSHDOWN_MODE) {
 }
 
 DeltaCatalog::~DeltaCatalog() = default;

--- a/src/storage/delta_catalog.cpp
+++ b/src/storage/delta_catalog.cpp
@@ -11,7 +11,7 @@
 namespace duckdb {
 
 DeltaCatalog::DeltaCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode)
-    : Catalog(db_p), path(path), access_mode(access_mode), use_cache(false), pushdown_partition_info(false) {
+    : Catalog(db_p), path(path), access_mode(access_mode), use_cache(false), pushdown_partition_info(false), filter_pushdown_mode(DEFAULT_PUSHDOWN_MODE) {
 }
 
 DeltaCatalog::~DeltaCatalog() = default;

--- a/src/storage/delta_table_entry.cpp
+++ b/src/storage/delta_table_entry.cpp
@@ -48,7 +48,7 @@ TableFunction DeltaTableEntry::GetScanFunction(ClientContext &context, unique_pt
 	vector<string> names;
 	TableFunctionRef empty_ref;
 
-    param_map.insert({"pushdown_partition_info", delta_catalog.pushdown_partition_info});
+	param_map.insert({"pushdown_partition_info", delta_catalog.pushdown_partition_info});
 
 	TableFunctionBindInput bind_input(inputs, param_map, return_types, names, nullptr, nullptr, delta_scan_function,
 	                                  empty_ref);

--- a/src/storage/delta_table_entry.cpp
+++ b/src/storage/delta_table_entry.cpp
@@ -48,6 +48,8 @@ TableFunction DeltaTableEntry::GetScanFunction(ClientContext &context, unique_pt
 	vector<string> names;
 	TableFunctionRef empty_ref;
 
+    param_map.insert({"pushdown_partition_info", delta_catalog.pushdown_partition_info});
+
 	TableFunctionBindInput bind_input(inputs, param_map, return_types, names, nullptr, nullptr, delta_scan_function,
 	                                  empty_ref);
 

--- a/src/storage/delta_table_entry.cpp
+++ b/src/storage/delta_table_entry.cpp
@@ -48,7 +48,9 @@ TableFunction DeltaTableEntry::GetScanFunction(ClientContext &context, unique_pt
 	vector<string> names;
 	TableFunctionRef empty_ref;
 
+    // Propagate settings
 	param_map.insert({"pushdown_partition_info", delta_catalog.pushdown_partition_info});
+	param_map.insert({"pushdown_filters", DeltaEnumUtils::ToString(delta_catalog.filter_pushdown_mode)});
 
 	TableFunctionBindInput bind_input(inputs, param_map, return_types, names, nullptr, nullptr, delta_scan_function,
 	                                  empty_ref);

--- a/src/storage/delta_table_entry.cpp
+++ b/src/storage/delta_table_entry.cpp
@@ -48,7 +48,7 @@ TableFunction DeltaTableEntry::GetScanFunction(ClientContext &context, unique_pt
 	vector<string> names;
 	TableFunctionRef empty_ref;
 
-    // Propagate settings
+	// Propagate settings
 	param_map.insert({"pushdown_partition_info", delta_catalog.pushdown_partition_info});
 	param_map.insert({"pushdown_filters", DeltaEnumUtils::ToString(delta_catalog.filter_pushdown_mode)});
 

--- a/test/sql/dat/custom_parameters.test
+++ b/test/sql/dat/custom_parameters.test
@@ -43,4 +43,4 @@ query IIIII
 SELECT filter_type, files_before, files_after, filters_before, filters_after FROM delta_filter_pushdown_log() order by filter_type;
 ----
 dynamic	1	1	[letter='d']	[letter='d']
-regular	2	1	[]	[letter='d']
+constant	2	1	[]	[letter='d']

--- a/test/sql/dat/custom_parameters.test
+++ b/test/sql/dat/custom_parameters.test
@@ -42,5 +42,5 @@ WHERE filename != 'henk' and letter = 'd'
 query IIIII
 SELECT filter_type, files_before, files_after, filters_before, filters_after FROM delta_filter_pushdown_log() order by filter_type;
 ----
-dynamic	1	1	[letter='d']	[letter='d']
 constant	2	1	[]	[letter='d']
+dynamic	1	1	[letter='d']	[letter='d']

--- a/test/sql/generated/file_skipping_dynamic.test
+++ b/test/sql/generated/file_skipping_dynamic.test
@@ -14,7 +14,7 @@ set enable_logging=true;
 statement ok
 set logging_level = 'INFO';
 
-### First we try regular pushdown
+### First we try constant pushdown
 query IIII
 SELECT value1, value3, value2 as v2, part
 FROM delta_scan('./data/generated/test_file_skipping_2/int/delta_lake')
@@ -26,7 +26,7 @@ query IIIII
 SELECT filter_type, filters_before, filters_after, files_before, files_after
 FROM delta_filter_pushdown_log()
 ----
-regular	[]	[value3=1002, value2=102]	5	1
+constant	[]	[value3=1002, value2=102]	5	1
 
 # Clear logging storage
 statement ok
@@ -44,7 +44,7 @@ query IIIII
 SELECT filter_type, filters_before, filters_after, files_before, files_after
 FROM delta_filter_pushdown_log()
 ----
-regular	[]	[value3=1002]	5	1
+constant	[]	[value3=1002]	5	1
 
 # Clear logging storage
 statement ok
@@ -105,7 +105,7 @@ dynamic	[]	[part=2]	5	5
 statement ok
 set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
 
-# Now let's get funky: a dynamic join filter plus a regular filter
+# Now let's get funky: a dynamic join filter plus a constant filter
 query IIII
 SELECT value1, value3, value2 as v2, part
 FROM delta_scan('./data/generated/test_file_skipping_2/int/delta_lake')
@@ -120,13 +120,13 @@ FROM delta_filter_pushdown_log()
 ORDER BY filter_type
 ----
 dynamic	[value1=13]	[value2=103, value1=13]	1	1
-regular	[]	[value1=13]	5	1
+constant	[]	[value1=13]	5	1
 
 # Clear logging storage
 statement ok
 set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
 
-# Slightly weird case here: pushing down an identical dynamic filter and regular filter will make it show up twice with the second doing nothing
+# Slightly weird case here: pushing down an identical dynamic filter and constant filter will make it show up twice with the second doing nothing
 query IIII
 SELECT value1, value3, value2 as v2, part
 FROM delta_scan('./data/generated/test_file_skipping_2/int/delta_lake')
@@ -141,7 +141,7 @@ FROM delta_filter_pushdown_log()
 ORDER BY filter_type
 ----
 dynamic	[value1=13]	[value1=13 AND value1=13 AND value1=13]	1	1
-regular	[]	[value1=13]	5	1
+constant	[]	[value1=13]	5	1
 
 # Clear logging storage
 statement ok
@@ -172,4 +172,4 @@ FROM delta_filter_pushdown_log()
 ORDER BY filter_type
 ----
 dynamic	[]	[value1=12]	NULL	NULL
-regular	[]	[value1=12]	NULL	NULL
+constant	[]	[value1=12]	NULL	NULL

--- a/test/sql/generated/file_skipping_dynamic.test
+++ b/test/sql/generated/file_skipping_dynamic.test
@@ -119,8 +119,8 @@ SELECT filter_type, filters_before, filters_after, files_before, files_after
 FROM delta_filter_pushdown_log()
 ORDER BY filter_type
 ----
-dynamic	[value1=13]	[value2=103, value1=13]	1	1
 constant	[]	[value1=13]	5	1
+dynamic	[value1=13]	[value2=103, value1=13]	1	1
 
 # Clear logging storage
 statement ok
@@ -140,8 +140,8 @@ SELECT filter_type, filters_before, filters_after, files_before, files_after
 FROM delta_filter_pushdown_log()
 ORDER BY filter_type
 ----
-dynamic	[value1=13]	[value1=13 AND value1=13 AND value1=13]	1	1
 constant	[]	[value1=13]	5	1
+dynamic	[value1=13]	[value1=13 AND value1=13 AND value1=13]	1	1
 
 # Clear logging storage
 statement ok
@@ -171,5 +171,5 @@ SELECT filter_type, filters_before, filters_after, files_before, files_after
 FROM delta_filter_pushdown_log()
 ORDER BY filter_type
 ----
-dynamic	[]	[value1=12]	NULL	NULL
 constant	[]	[value1=12]	NULL	NULL
+dynamic	[]	[value1=12]	NULL	NULL

--- a/test/sql/generated/file_skipping_params.test
+++ b/test/sql/generated/file_skipping_params.test
@@ -1,0 +1,118 @@
+# name: test/sql/generated/file_skipping_params.test
+# description: Test filter pushdown parameters
+# group: [delta_generated]
+
+require parquet
+
+require delta
+
+require-env GENERATED_DATA_AVAILABLE
+
+statement ok
+set enable_logging=true;
+
+statement ok
+set logging_level = 'INFO';
+
+# delta_scan: ALL filters
+query IIII
+SELECT value1, value3, value2 as v2, part
+FROM delta_scan('./data/generated/test_file_skipping_2/int/delta_lake', pushdown_filters='all')
+WHERE value1=13 AND v2=(select 103)
+----
+13	1003	103	3
+
+query I
+SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
+----
+constant
+dynamic
+
+statement ok
+set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+
+# delta_scan: constant only filters
+query IIII
+SELECT value1, value3, value2 as v2, part
+FROM delta_scan('./data/generated/test_file_skipping_2/int/delta_lake', pushdown_filters='constant_only')
+WHERE value1=13 AND v2=(select 103)
+----
+13	1003	103	3
+
+query I
+SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
+----
+constant
+
+statement ok
+set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+
+# delta_scan: dynamic only filters
+query IIII
+SELECT value1, value3, value2 as v2, part
+FROM delta_scan('./data/generated/test_file_skipping_2/int/delta_lake', pushdown_filters='dynamic_only')
+WHERE value1=13 AND v2=(select 103)
+----
+13	1003	103	3
+
+query I
+SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
+----
+dynamic
+
+statement ok
+set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+
+# delta_scan: no filters
+query IIII
+SELECT value1, value3, value2 as v2, part
+FROM delta_scan('./data/generated/test_file_skipping_2/int/delta_lake', pushdown_filters='none')
+WHERE value1=13 AND v2=(select 103)
+----
+13	1003	103	3
+
+query I
+SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
+----
+
+statement ok
+set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+
+# attach: default = all filters
+statement ok
+ATTACH './data/generated/test_file_skipping_2/int/delta_lake' as dt1 (TYPE delta)
+
+query IIII
+SELECT value1, value3, value2 as v2, part
+FROM dt1
+WHERE value1=13 AND v2=(select 103)
+----
+13	1003	103	3
+
+query I
+SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
+----
+constant
+dynamic
+
+statement ok
+set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+
+# attach: pushdown mode can be configured
+statement ok
+ATTACH './data/generated/test_file_skipping_2/int/delta_lake' as dt2 (TYPE delta, PUSHDOWN_FILTERS 'dynamic_only')
+
+query IIII
+SELECT value1, value3, value2 as v2, part
+FROM dt2
+WHERE value1=13 AND v2=(select 103)
+----
+13	1003	103	3
+
+query I
+SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
+----
+dynamic
+
+statement ok
+set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;

--- a/test/sql/generated/partitioned_large.test
+++ b/test/sql/generated/partitioned_large.test
@@ -14,11 +14,10 @@ CREATE VIEW t AS SELECT part::INT as part, sum(i) as value
                  GROUP BY part
                  ORDER BY part
 
-# By default, we don't propagate paritioning info TODO: fix this once delta-kernel-rs can give us partitions from a snapshot
 query II
 EXPLAIN FROM t
 ----
-physical_plan	<!REGEX>:.*PARTITIONED_AGGREGATE.*
+physical_plan	<REGEX>:.*PARTITIONED_AGGREGATE.*
 
 # With a projection and delta constant column
 query II
@@ -45,17 +44,17 @@ FROM t
 18	2504000
 19	2504500
 
-# Now we enable pushing down partition info to get the partitioning aware operator
+# We can disable pushing down partition information
 statement ok
 CREATE VIEW t2 AS SELECT part::INT as part, sum(i) as value
-                 FROM delta_scan('./data/generated/simple_partitioned_large/delta_lake', delta_file_number=1, pushdown_partition_info=1)
+                 FROM delta_scan('./data/generated/simple_partitioned_large/delta_lake', delta_file_number=1, pushdown_partition_info=0)
                  GROUP BY part
                  ORDER BY part
 
 query II
 EXPLAIN FROM t2
 ----
-physical_plan	<REGEX>:.*PARTITIONED_AGGREGATE.*
+physical_plan	<!REGEX>:.*PARTITIONED_AGGREGATE.*
 
 # With a projection and delta constant column
 query II
@@ -95,11 +94,11 @@ CREATE VIEW t3 AS SELECT part::INT as part, sum(i) as value
 query II
 EXPLAIN FROM t3
 ----
-physical_plan	<!REGEX>:.*PARTITIONED_AGGREGATE.*
+physical_plan	<REGEX>:.*PARTITIONED_AGGREGATE.*
 
 # Then for ATTACH, with default settings partition info pushdown
 statement ok
-ATTACH './data/generated/simple_partitioned_large/delta_lake' as dt2 (TYPE DELTA, PUSHDOWN_PARTITION_INFO 1)
+ATTACH './data/generated/simple_partitioned_large/delta_lake' as dt2 (TYPE DELTA, PUSHDOWN_PARTITION_INFO 0)
 
 statement ok
 CREATE VIEW t4 AS SELECT part::INT as part, sum(i) as value
@@ -110,5 +109,5 @@ CREATE VIEW t4 AS SELECT part::INT as part, sum(i) as value
 query II
 EXPLAIN FROM t4
 ----
-physical_plan	<REGEX>:.*PARTITIONED_AGGREGATE.*
+physical_plan	<!REGEX>:.*PARTITIONED_AGGREGATE.*
 

--- a/test/sql/generated/partitioned_large.test
+++ b/test/sql/generated/partitioned_large.test
@@ -14,10 +14,11 @@ CREATE VIEW t AS SELECT part::INT as part, sum(i) as value
                  GROUP BY part
                  ORDER BY part
 
+# By default, we don't propagate paritioning info TODO: fix this once delta-kernel-rs can give us partitions from a snapshot
 query II
 EXPLAIN FROM t
 ----
-physical_plan	<REGEX>:.*PARTITIONED_AGGREGATE.*
+physical_plan	<!REGEX>:.*PARTITIONED_AGGREGATE.*
 
 # With a projection and delta constant column
 query II
@@ -43,3 +44,71 @@ FROM t
 17	2503500
 18	2504000
 19	2504500
+
+# Now we enable pushing down partition info to get the partitioning aware operator
+statement ok
+CREATE VIEW t2 AS SELECT part::INT as part, sum(i) as value
+                 FROM delta_scan('./data/generated/simple_partitioned_large/delta_lake', delta_file_number=1, pushdown_partition_info=1)
+                 GROUP BY part
+                 ORDER BY part
+
+query II
+EXPLAIN FROM t2
+----
+physical_plan	<REGEX>:.*PARTITIONED_AGGREGATE.*
+
+# With a projection and delta constant column
+query II
+FROM t2
+----
+0	2495000
+1	2495500
+2	2496000
+3	2496500
+4	2497000
+5	2497500
+6	2498000
+7	2498500
+8	2499000
+9	2499500
+10	2500000
+11	2500500
+12	2501000
+13	2501500
+14	2502000
+15	2502500
+16	2503000
+17	2503500
+18	2504000
+19	2504500
+
+# Now we repeat for ATTACH, first with default settings
+statement ok
+ATTACH './data/generated/simple_partitioned_large/delta_lake' as dt1 (TYPE DELTA)
+
+statement ok
+CREATE VIEW t3 AS SELECT part::INT as part, sum(i) as value
+                 FROM dt1
+                 GROUP BY part
+                 ORDER BY part
+
+query II
+EXPLAIN FROM t3
+----
+physical_plan	<!REGEX>:.*PARTITIONED_AGGREGATE.*
+
+# Then for ATTACH, with default settings partition info pushdown
+statement ok
+ATTACH './data/generated/simple_partitioned_large/delta_lake' as dt2 (TYPE DELTA, PUSHDOWN_PARTITION_INFO 1)
+
+statement ok
+CREATE VIEW t4 AS SELECT part::INT as part, sum(i) as value
+                 FROM dt2
+                 GROUP BY part
+                 ORDER BY part
+
+query II
+EXPLAIN FROM t4
+----
+physical_plan	<REGEX>:.*PARTITIONED_AGGREGATE.*
+


### PR DESCRIPTION
In https://github.com/duckdb/duckdb-delta/pull/147 we introduced partition info pushdown and filter pushdown. 

However, after some more testing I realize that this PR introduced performance regressions on high latency filesystems. The reason is that these changes were introducing a lot of unnecessary delta metadata (re)scanning.

This PR adds configuration settings to enable and disable both filter pushdown and partition info pushdown:

For filter pushdown we can now do 
```SQL
-- default (all)
SELECT * FROM delta_scan('...', pushdown_filters='all') 

-- alternative settings
SELECT * FROM delta_scan('...', pushdown_filters='none')
SELECT * FROM delta_scan('...', pushdown_filters='constant_only')
SELECT * FROM delta_scan('...', pushdown_filters='dynamic_only')

-- also works with attach
ATTACH '...' as dt (TYPE delta, PUSHDOWN_FILTERS 'dynamic_only')
SELECT * FROM dt;
```

For partition info pushdown

```SQL
-- default (on)
SELECT * FROM delta_scan('...', pushdown_partition_info=1)

-- enabled
SELECT * FROM delta_scan('...', pushdown_partition_info=0)
```

### Future work
The reason partition info pushdown is disable for now is because the delta-kernel-rs library currently does not expose partition information from a snapshot. This means that we need to instantiate a scan to get the list of partition columns which is expensive because it happens before filter pushdown meaning that it will basically need to replay the whole delta metadata log just to get the partitions. Once more efficient ways to get the list of partition columns are exposed in the delta-kernel-rs library we can re-enable this by default