### PR TITLE
Switch to parsing transforms for partition values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ ExternalProject_Add(
   # the c++ headers. Currently, when bumping the kernel version, the produced
   # header in ./src/include/delta_kernel_ffi.hpp should be also bumped, applying
   # the fix
-  GIT_TAG v0.7.0
+  GIT_TAG v0.8.0
   # Prints the env variables passed to the cargo build to the terminal, useful
   # in debugging because passing them through CMake is an error-prone mess
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${RUST_UNSET_ENV_VARS}

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -301,7 +301,6 @@ static int64_t GetTruncatedDecimalValue(int64_t value_ms, uint64_t value_ls) {
 	return lower_cast;
 }
 
-// FIXME: this is not 100% correct yet: value_ms is ignored
 void ExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, int64_t value_ms, uint64_t value_ls,
                                             uint8_t precision, uint8_t scale) {
 	try {

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -1,6 +1,9 @@
 #include "delta_utils.hpp"
 
+#include "duckdb/common/operator/decimal_cast_operators.hpp"
+
 #include "duckdb.hpp"
+#include "../duckdb/third_party/catch/catch.hpp"
 #include "duckdb/common/types/decimal.hpp"
 #include "duckdb/main/extension_util.hpp"
 #include "duckdb/main/database.hpp"
@@ -28,9 +31,7 @@ void ExpressionVisitor::VisitComparisonExpression(void *state, uintptr_t sibling
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-unique_ptr<vector<unique_ptr<ParsedExpression>>>
-ExpressionVisitor::VisitKernelExpression(const ffi::Handle<ffi::SharedExpression> *expression) {
-	ExpressionVisitor state;
+ffi::EngineExpressionVisitor ExpressionVisitor::CreateVisitor(ExpressionVisitor &state) {
 	ffi::EngineExpressionVisitor visitor;
 
 	visitor.data = &state;
@@ -85,6 +86,28 @@ ExpressionVisitor::VisitKernelExpression(const ffi::Handle<ffi::SharedExpression
 
 	visitor.visit_not = &VisitNotExpression;
 	visitor.visit_is_null = &VisitIsNullExpression;
+
+	return visitor;
+}
+
+unique_ptr<vector<unique_ptr<ParsedExpression>>>
+ExpressionVisitor::VisitKernelExpression(const ffi::Expression *expression) {
+	ExpressionVisitor state;
+	auto visitor = CreateVisitor(state);
+
+	uintptr_t result = ffi::visit_expression_ref(expression, &visitor);
+
+	if (state.error.HasError()) {
+		state.error.Throw();
+	}
+
+	return state.TakeFieldList(result);
+}
+
+unique_ptr<vector<unique_ptr<ParsedExpression>>>
+ExpressionVisitor::VisitKernelExpression(const ffi::Handle<ffi::SharedExpression> *expression) {
+	ExpressionVisitor state;
+	auto visitor = CreateVisitor(state);
 
 	uintptr_t result = ffi::visit_expression(expression, &visitor);
 
@@ -254,14 +277,41 @@ void ExpressionVisitor::VisitIsNullExpression(void *state, uintptr_t sibling_lis
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
+// Note: hack to get the DECIMAL thing goin
+template <class hugeint_t>
+hugeint_t &Value::GetReferenceUnsafe() {
+	D_ASSERT(type_.InternalType() == PhysicalType::INT128);
+	return value_.hugeint;
+}
+
+// This function is a workaround for the fact that duckdb disallows using hugeints to store decimals with precision < 18
+// whereas kernel does allow this.
+static int64_t GetTruncatedDecimalValue(int64_t value_ms, uint64_t value_ls) {
+	// First trim msb from lower half
+	auto new_value_ls = value_ls << 1;
+	new_value_ls = new_value_ls >> 1;
+
+	// Now cast the lower half to signed
+	auto lower_cast = UnsafeNumericCast<int64_t>(value_ls);
+
+	// If value_ms was negative, we need to invert
+	if (value_ms < 0) {
+		lower_cast = -lower_cast;
+	}
+	return lower_cast;
+}
+
 // FIXME: this is not 100% correct yet: value_ms is ignored
-void ExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, uint64_t value_ms,
-                                            uint64_t value_ls, uint8_t precision, uint8_t scale) {
+void ExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, int64_t value_ms, uint64_t value_ls,
+                                            uint8_t precision, uint8_t scale) {
 	try {
-		if (precision >= Decimal::MAX_WIDTH_INT64 || value_ls > (uint64_t)NumericLimits<int64_t>::Maximum()) {
-			throw NotImplementedException("ExpressionVisitor::VisitDecimalLiteral HugeInt decimals");
+		Value decimal_value;
+		if (precision < Decimal::MAX_WIDTH_INT64) {
+			decimal_value = Value::DECIMAL(GetTruncatedDecimalValue(value_ms, value_ls), precision, scale);
+		} else {
+			decimal_value = Value::DECIMAL({value_ms, value_ls}, precision, scale);
 		}
-		auto expression = make_uniq<ConstantExpression>(Value::DECIMAL(42, 18, 10));
+		auto expression = make_uniq<ConstantExpression>(decimal_value);
 		static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 	} catch (Exception &e) {
 		static_cast<ExpressionVisitor *>(state)->error = ErrorData(e);
@@ -272,9 +322,17 @@ void ExpressionVisitor::VisitColumnExpression(void *state, uintptr_t sibling_lis
 	auto expression = make_uniq<ColumnRefExpression>(string(name.ptr, name.len));
 	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
+
 void ExpressionVisitor::VisitStructExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id,
-	                                                      std::move(make_uniq<ConstantExpression>(Value(42))));
+	auto state_cast = static_cast<ExpressionVisitor *>(state);
+
+	auto children_values = state_cast->TakeFieldList(child_list_id);
+	if (!children_values) {
+		return;
+	}
+
+	unique_ptr<ParsedExpression> expression = make_uniq<FunctionExpression>("struct_pack", std::move(*children_values));
+	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
 uintptr_t ExpressionVisitor::MakeFieldList(ExpressionVisitor *state, uintptr_t capacity_hint) {

--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
+++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
@@ -208,12 +208,8 @@ void DeltaMultiFileReader::FinalizeBind(const MultiFileReaderOptions &file_optio
 			auto col_partition_entry = file_metadata.partition_map.find(global_columns[col_id].name);
 			if (col_partition_entry != file_metadata.partition_map.end()) {
 				auto &current_type = global_columns[col_id].type;
-				if (current_type == LogicalType::BLOB) {
-					reader_data.constant_map.emplace_back(i, Value::BLOB_RAW(col_partition_entry->second));
-				} else {
-					auto maybe_value = Value(col_partition_entry->second).DefaultCastAs(current_type);
-					reader_data.constant_map.emplace_back(i, maybe_value);
-				}
+				auto maybe_value = Value(col_partition_entry->second).DefaultCastAs(current_type);
+				reader_data.constant_map.emplace_back(i, maybe_value);
 			}
 		}
 	}

--- a/src/include/delta_kernel_ffi.hpp
+++ b/src/include/delta_kernel_ffi.hpp
@@ -430,7 +430,7 @@ struct EngineExpressionVisitor {
 	/// Visit a 128bit `decimal` value with the given precision and scale. The 128bit integer
 	/// is split into the most significant 64 bits in `value_ms`, and the least significant 64
 	/// bits in `value_ls`. The `decimal` belongs to the list identified by `sibling_list_id`.
-	void (*visit_literal_decimal)(void *data, uintptr_t sibling_list_id, uint64_t value_ms, uint64_t value_ls,
+	void (*visit_literal_decimal)(void *data, uintptr_t sibling_list_id, int64_t value_ms, uint64_t value_ls,
 	                              uint8_t precision, uint8_t scale);
 	/// Visit a struct literal belonging to the list identified by `sibling_list_id`.
 	/// The field names of the struct are in a list identified by `child_field_list_id`.
@@ -762,8 +762,20 @@ void free_schema(Handle<SharedSchema> schema);
 ///
 /// # Safety
 ///
-/// Caller is responsible for passing a valid handle.
+/// Caller is responsible for passing a valid snapshot handle.
 NullableCvoid snapshot_table_root(Handle<SharedSnapshot> snapshot, AllocateStringFn allocate_fn);
+
+/// Get a count of the number of partition columns for this snapshot
+///
+/// # Safety
+/// Caller is responsible for passing a valid snapshot handle
+uintptr_t get_partition_column_count(Handle<SharedSnapshot> snapshot);
+
+/// Get an iterator of the list of partition columns for this snapshot.
+///
+/// # Safety
+/// Caller is responsible for passing a valid snapshot handle.
+Handle<StringSliceIterator> get_partition_columns(Handle<SharedSnapshot> snapshot);
 
 /// # Safety
 ///
@@ -1022,18 +1034,6 @@ Handle<SharedSchema> get_global_read_schema(Handle<SharedGlobalScanState> state)
 /// # Safety
 /// Engine is responsible for providing a valid GlobalScanState pointer
 Handle<SharedSchema> get_global_logical_schema(Handle<SharedGlobalScanState> state);
-
-/// Get a count of the number of partition columns for this scan
-///
-/// # Safety
-/// Caller is responsible for passing a valid global scan pointer.
-uintptr_t get_partition_column_count(Handle<SharedGlobalScanState> state);
-
-/// Get an iterator of the list of partition columns for this scan.
-///
-/// # Safety
-/// Caller is responsible for passing a valid global scan pointer.
-Handle<StringSliceIterator> get_partition_columns(Handle<SharedGlobalScanState> state);
 
 /// # Safety
 ///

--- a/src/include/delta_utils.hpp
+++ b/src/include/delta_utils.hpp
@@ -23,6 +23,8 @@ class ExpressionVisitor : public ffi::EngineExpressionVisitor {
 public:
 	unique_ptr<vector<unique_ptr<ParsedExpression>>>
 	VisitKernelExpression(const ffi::Handle<ffi::SharedExpression> *expression);
+	unique_ptr<vector<unique_ptr<ParsedExpression>>> VisitKernelExpression(const ffi::Expression *expression);
+	ffi::EngineExpressionVisitor CreateVisitor(ExpressionVisitor &state);
 
 private:
 	unordered_map<uintptr_t, unique_ptr<FieldList>> inflight_lists;
@@ -60,7 +62,7 @@ private:
 	static void VisitArrayLiteral(void *state, uintptr_t sibling_list_id, uintptr_t child_id);
 	static void VisitStructLiteral(void *data, uintptr_t sibling_list_id, uintptr_t child_field_list_value,
 	                               uintptr_t child_value_list_id);
-	static void VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, uint64_t value_ms, uint64_t value_ls,
+	static void VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, int64_t value_ms, uint64_t value_ls,
 	                                uint8_t precision, uint8_t scale);
 	static void VisitColumnExpression(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name);
 	static void VisitStructExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id);

--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
@@ -32,7 +32,7 @@ struct DeltaFileMetaData {
 	idx_t file_number = DConstants::INVALID_INDEX;
 	idx_t cardinality = DConstants::INVALID_INDEX;
 	ffi::KernelBoolSlice selection_vector = {nullptr, 0};
-	case_insensitive_map_t<string> partition_map;
+	case_insensitive_map_t<Value> partition_map;
 };
 
 //! The DeltaMultiFileList implements the MultiFileList API to allow injecting it into the regular DuckDB parquet scan
@@ -103,6 +103,7 @@ protected:
 	mutable KernelScanDataIterator scan_data_iterator;
 
 	mutable vector<string> partitions;
+	mutable vector<idx_t> partition_ids;
 
 	//! Current file list resolution state
 	mutable bool initialized_snapshot = false;
@@ -135,7 +136,7 @@ struct ScanDataCallBack {
 	                          const struct ffi::CStringMap *partition_values);
 	static void VisitCallbackInternal(ffi::NullableCvoid engine_context, struct ffi::KernelStringSlice path,
 	                                  int64_t size, const ffi::Stats *stats, const ffi::DvInfo *dv_info,
-	                                  const struct ffi::CStringMap *partition_values);
+	                                  const ffi::Expression *transform);
 
 	const DeltaMultiFileList &snapshot;
 	ErrorData error;

--- a/test/sql/main/test_expression.test
+++ b/test/sql/main/test_expression.test
@@ -6,8 +6,6 @@ require parquet
 
 require delta
 
-# TODO still broken:
-# - Decimal
 query I
 SELECT unnest(get_delta_test_expression())
 ----

--- a/test/sql/main/test_expression.test
+++ b/test/sql/main/test_expression.test
@@ -8,7 +8,6 @@ require delta
 
 # TODO still broken:
 # - Decimal
-# - StructExpression
 query I
 SELECT unnest(get_delta_test_expression())
 ----
@@ -29,11 +28,11 @@ false
 '1970-01-01 00:00:00.0001'::TIMESTAMP
 '1970-02-02'::DATE
 '\x00\x00\xDE\xAD\xBE\xEF\xCA\xFE'::BLOB
-0.0000000042
+0.001
 NULL
 struct_pack("'top'" := struct_pack("'a'" := 500, "'b'" := list_value(5, 0)))
 list_value(5, 0)
-42
+struct_pack((5 OR 20))
 not((col is NULL))
 (0 IN (0))
 (0 + 0)


### PR DESCRIPTION
This PR switches the way we get partition values from kernel. Before we would use the partition map to do this. After this PR we switch to parsing the transform expression.

In the process we bump kernel to v0.8.0