### PR TITLE
cleanup kernel error handling

### DIFF
--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
@@ -85,8 +85,12 @@ protected:
 
 	template <class T>
 	T TryUnpackKernelResult(ffi::ExternResult<T> result) const {
-		return KernelUtils::UnpackResult<T>(
-		    result, StringUtil::Format("While trying to read from delta table: '%s'", paths[0]));
+		T return_value;
+		auto res = KernelUtils::TryUnpackResult<T>(result, return_value);
+		if (res.HasError()) {
+			res.Throw();
+		}
+		return return_value;
 	}
 
 protected:

--- a/test/sql/main/test_error_messages.test
+++ b/test/sql/main/test_error_messages.test
@@ -1,0 +1,49 @@
+# name: test/sql/main/test_error_messages.test
+# description: Test that clean error messages are generated
+# group: [delta_generated]
+
+require parquet
+
+require delta
+
+require httpfs
+
+statement error
+FROM delta_scan('./doesnt_exist_and_never_will_exist_i_hope');
+----
+IO Error: DeltKernel InvalidTableLocationError (28): Invalid table location: Path does not exist:
+
+statement ok
+ATTACH './doesnt_exist_and_never_will_exist_i_hope' AS s1 (TYPE delta);
+
+statement error
+SHOW ALL TABLES;
+----
+IO Error: DeltKernel InvalidTableLocationError (28): Invalid table location: Path does not exist:
+
+statement ok
+DETACH s1;
+
+statement ok
+CREATE SECRET s1 (
+    TYPE S3,
+    ENDPOINT 'http://localhost:1337'
+)
+
+statement error
+FROM delta_scan('s3://bucket/doesnt/exist/either');
+----
+IO Error: DeltKernel ObjectStoreError (8): Error interacting with object store: Generic S3 error: Error after
+
+statement error
+FROM delta_scan('duck://bucket/doesnt/exist/either');
+----
+IO Error: DeltKernel ObjectStoreError (8): Error interacting with object store: Generic URL error: Unable to recognise URL
+
+statement ok
+ATTACH 's3://bucket/doesnt/exist/either' AS s1 (TYPE delta);
+
+statement error
+SHOW ALL TABLES;
+----
+IO Error: DeltKernel ObjectStoreError (8): Error interacting with object store: Generic S3 error: Error after


### PR DESCRIPTION
fixes https://github.com/duckdb/duckdb-delta/issues/29

Avoids throwing in visitor callbacks because that crashes in ugly ways. Reworks the API to make it harder to accidentally do that.