### PR TITLE
Bump duckdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(src/include)
 set(EXTENSION_SOURCES
     src/delta_extension.cpp
     src/delta_functions.cpp
+    src/delta_log_types.cpp
     src/delta_macros.cpp
     src/delta_utils.cpp
     src/functions/delta_scan/delta_scan.cpp

--- a/src/delta_extension.cpp
+++ b/src/delta_extension.cpp
@@ -4,6 +4,7 @@
 
 #include "delta_utils.hpp"
 #include "delta_functions.hpp"
+#include "delta_log_types.hpp"
 #include "delta_macros.hpp"
 #include "storage/delta_catalog.hpp"
 #include "storage/delta_transaction_manager.hpp"
@@ -82,6 +83,8 @@ static void LoadInternal(DatabaseInstance &instance) {
 	    LogicalType::BOOLEAN, Value(false), LoggerCallback::DuckDBSettingCallBack);
 
 	DeltaMacros::RegisterMacros(instance);
+
+    DeltaLogTypes::RegisterLogTypes(instance);
 
 	LoggerCallback::Initialize(instance);
 }

--- a/src/delta_extension.cpp
+++ b/src/delta_extension.cpp
@@ -84,7 +84,7 @@ static void LoadInternal(DatabaseInstance &instance) {
 
 	DeltaMacros::RegisterMacros(instance);
 
-    DeltaLogTypes::RegisterLogTypes(instance);
+	DeltaLogTypes::RegisterLogTypes(instance);
 
 	LoggerCallback::Initialize(instance);
 }

--- a/src/delta_log_types.cpp
+++ b/src/delta_log_types.cpp
@@ -9,32 +9,28 @@ DeltaKernelLogType::DeltaKernelLogType() : LogType(NAME, LEVEL, GetLogType()) {
 }
 
 LogicalType DeltaKernelLogType::GetLogType() {
-    child_list_t<LogicalType> request_child_list = {
-        {"target", LogicalType::VARCHAR},
-        {"message", LogicalType::VARCHAR},
-        {"file", LogicalType::VARCHAR},
-        {"line", LogicalType::UINTEGER}
-    };
-    return LogicalType::STRUCT(request_child_list);
+	child_list_t<LogicalType> request_child_list = {{"target", LogicalType::VARCHAR},
+	                                                {"message", LogicalType::VARCHAR},
+	                                                {"file", LogicalType::VARCHAR},
+	                                                {"line", LogicalType::UINTEGER}};
+	return LogicalType::STRUCT(request_child_list);
 }
 
 string DeltaKernelLogType::ConstructLogMessage(ffi::Event event) {
-    Value file, line;
+	Value file, line;
 
-    auto file_string = KernelUtils::FromDeltaString(event.file);
-    if (!file_string.empty()) {
-        file = Value(KernelUtils::FromDeltaString(event.file));
-        line = Value::UINTEGER(event.line);
-    }
+	auto file_string = KernelUtils::FromDeltaString(event.file);
+	if (!file_string.empty()) {
+		file = Value(KernelUtils::FromDeltaString(event.file));
+		line = Value::UINTEGER(event.line);
+	}
 
-    child_list_t<Value> message_child_list = {
-        {"target", Value(KernelUtils::FromDeltaString(event.target))},
-        {"message", Value(KernelUtils::FromDeltaString(event.message))},
-        {"file", Value(file)},
-        {"line", Value(line)}
-    };
+	child_list_t<Value> message_child_list = {{"target", Value(KernelUtils::FromDeltaString(event.target))},
+	                                          {"message", Value(KernelUtils::FromDeltaString(event.message))},
+	                                          {"file", Value(file)},
+	                                          {"line", Value(line)}};
 
-    return Value::STRUCT(message_child_list).ToString();
+	return Value::STRUCT(message_child_list).ToString();
 }
 
 }; // namespace duckdb

--- a/src/delta_log_types.cpp
+++ b/src/delta_log_types.cpp
@@ -1,0 +1,40 @@
+#include "delta_log_types.hpp"
+#include "delta_utils.hpp"
+
+namespace duckdb {
+
+constexpr LogLevel DeltaKernelLogType::LEVEL;
+
+DeltaKernelLogType::DeltaKernelLogType() : LogType(NAME, LEVEL, GetLogType()) {
+}
+
+LogicalType DeltaKernelLogType::GetLogType() {
+    child_list_t<LogicalType> request_child_list = {
+        {"target", LogicalType::VARCHAR},
+        {"message", LogicalType::VARCHAR},
+        {"file", LogicalType::VARCHAR},
+        {"line", LogicalType::UINTEGER}
+    };
+    return LogicalType::STRUCT(request_child_list);
+}
+
+string DeltaKernelLogType::ConstructLogMessage(ffi::Event event) {
+    Value file, line;
+
+    auto file_string = KernelUtils::FromDeltaString(event.file);
+    if (!file_string.empty()) {
+        file = Value(KernelUtils::FromDeltaString(event.file));
+        line = Value::UINTEGER(event.line);
+    }
+
+    child_list_t<Value> message_child_list = {
+        {"target", Value(KernelUtils::FromDeltaString(event.target))},
+        {"message", Value(KernelUtils::FromDeltaString(event.message))},
+        {"file", Value(file)},
+        {"line", Value(line)}
+    };
+
+    return Value::STRUCT(message_child_list).ToString();
+}
+
+}; // namespace duckdb

--- a/src/delta_macros.cpp
+++ b/src/delta_macros.cpp
@@ -9,6 +9,7 @@
 
 namespace duckdb {
 
+// TODO: use Structured logging for this
 // Macro to fetch the pushed down filters for the most recent query
 static constexpr auto DELTA_FILTER_PUSHDOWN_MACRO = R"(
 SELECT
@@ -24,7 +25,7 @@ JOIN duckdb_logs as l2 ON
     l1.transaction_id = l2.transaction_id
 WHERE
     l2.type='delta.FilterPushdown' AND
-    l1.type = 'duckdb.ClientContext.BeginQuery'
+    l1.type = 'QueryLog'
 ORDER BY l1.transaction_id
 )";
 

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -1,5 +1,6 @@
 #include "delta_utils.hpp"
 
+#include "delta_log_types.hpp"
 #include "duckdb/common/operator/decimal_cast_operators.hpp"
 
 #include "duckdb.hpp"
@@ -775,25 +776,13 @@ void LoggerCallback::Initialize(DatabaseInstance &db_p) {
 	}
 }
 
-static string ConvertLogMessage(ffi::Event event) {
-	auto log_type = KernelUtils::FromDeltaString(event.target);
-	auto message = KernelUtils::FromDeltaString(event.message);
-	auto file = KernelUtils::FromDeltaString(event.file);
-	string constructed_log_message;
-	if (!file.empty()) {
-		constructed_log_message = StringUtil::Format("[%s] %s@%u : %s ", log_type, file, event.line, message);
-	} else {
-		constructed_log_message = message;
-	}
-
-	return constructed_log_message;
-}
 void LoggerCallback::CallbackEvent(ffi::Event event) {
 	auto &instance = GetInstance();
 	auto db_locked = instance.db.lock();
 	if (db_locked) {
-		auto transformed_log_level = GetDuckDBLogLevel(event.level);
-		DUCKDB_LOG(*db_locked, "delta.Kernel", transformed_log_level, ConvertLogMessage(event));
+	    // Note: this slightly offbeat invocation of logging API is because we are passing through the log level instead of using the same
+	    //       log level for every message of this log type. We may
+	    DUCKDB_LOG_INTERNAL(*db_locked, DeltaKernelLogType::NAME, GetDuckDBLogLevel(event.level), DeltaKernelLogType::ConstructLogMessage(event));
 	}
 }
 

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -780,9 +780,11 @@ void LoggerCallback::CallbackEvent(ffi::Event event) {
 	auto &instance = GetInstance();
 	auto db_locked = instance.db.lock();
 	if (db_locked) {
-	    // Note: this slightly offbeat invocation of logging API is because we are passing through the log level instead of using the same
-	    //       log level for every message of this log type. We may
-	    DUCKDB_LOG_INTERNAL(*db_locked, DeltaKernelLogType::NAME, GetDuckDBLogLevel(event.level), DeltaKernelLogType::ConstructLogMessage(event));
+		// Note: this slightly offbeat invocation of logging API is because we are passing through the log level instead
+		// of using the same
+		//       log level for every message of this log type. We may
+		DUCKDB_LOG_INTERNAL(*db_locked, DeltaKernelLogType::NAME, GetDuckDBLogLevel(event.level),
+		                    DeltaKernelLogType::ConstructLogMessage(event));
 	}
 }
 

--- a/src/include/delta_log_types.hpp
+++ b/src/include/delta_log_types.hpp
@@ -32,25 +32,6 @@ public:
 	}
 };
 
-class DeltaFilterPushdownLogType : public LogType {
-public:
-	static constexpr const char *NAME = "DeltaFilterPushdown";
-	static constexpr LogLevel LEVEL =
-	    LogLevel::LOG_INFO; // WARNING: DeltaKernelLogType is special in that it overrides this base logtype
-
-	//! Construct the log types
-	DeltaFilterPushdownLogType();
-
-	static LogicalType GetLogType();
-
-	static string ConstructLogMessage(ffi::Event event);
-
-	// FIXME: HTTPLogType should be structured probably
-	static string ConstructLogMessage(const string &str) {
-		return str;
-	}
-};
-
 class DeltaLogTypes {
 public:
 	static void RegisterLogTypes(DatabaseInstance &instance) {

--- a/src/include/delta_log_types.hpp
+++ b/src/include/delta_log_types.hpp
@@ -15,45 +15,47 @@ namespace duckdb {
 
 class DeltaKernelLogType : public LogType {
 public:
-    static constexpr const char *NAME = "DeltaKernel";
-    static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG; // WARNING: DeltaKernelLogType is special in that it overrides this base logtype
+	static constexpr const char *NAME = "DeltaKernel";
+	static constexpr LogLevel LEVEL =
+	    LogLevel::LOG_DEBUG; // WARNING: DeltaKernelLogType is special in that it overrides this base logtype
 
-    //! Construct the log types
-    DeltaKernelLogType();
+	//! Construct the log types
+	DeltaKernelLogType();
 
-    static LogicalType GetLogType();
+	static LogicalType GetLogType();
 
-    static string ConstructLogMessage(ffi::Event event);
+	static string ConstructLogMessage(ffi::Event event);
 
-    // FIXME: HTTPLogType should be structured probably
-    static string ConstructLogMessage(const string &str) {
-        return str;
-    }
+	// FIXME: HTTPLogType should be structured probably
+	static string ConstructLogMessage(const string &str) {
+		return str;
+	}
 };
 
 class DeltaFilterPushdownLogType : public LogType {
 public:
-    static constexpr const char *NAME = "DeltaFilterPushdown";
-    static constexpr LogLevel LEVEL = LogLevel::LOG_INFO; // WARNING: DeltaKernelLogType is special in that it overrides this base logtype
+	static constexpr const char *NAME = "DeltaFilterPushdown";
+	static constexpr LogLevel LEVEL =
+	    LogLevel::LOG_INFO; // WARNING: DeltaKernelLogType is special in that it overrides this base logtype
 
-    //! Construct the log types
-    DeltaFilterPushdownLogType();
+	//! Construct the log types
+	DeltaFilterPushdownLogType();
 
-    static LogicalType GetLogType();
+	static LogicalType GetLogType();
 
-    static string ConstructLogMessage(ffi::Event event);
+	static string ConstructLogMessage(ffi::Event event);
 
-    // FIXME: HTTPLogType should be structured probably
-    static string ConstructLogMessage(const string &str) {
-        return str;
-    }
+	// FIXME: HTTPLogType should be structured probably
+	static string ConstructLogMessage(const string &str) {
+		return str;
+	}
 };
 
 class DeltaLogTypes {
 public:
-    static void RegisterLogTypes(DatabaseInstance &instance) {
-        instance.GetLogManager().RegisterLogType(make_uniq<DeltaKernelLogType>());
-    }
+	static void RegisterLogTypes(DatabaseInstance &instance) {
+		instance.GetLogManager().RegisterLogType(make_uniq<DeltaKernelLogType>());
+	}
 };
 
 } // namespace duckdb

--- a/src/include/delta_log_types.hpp
+++ b/src/include/delta_log_types.hpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// delta_log_types.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "delta_kernel_ffi.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace duckdb {
+
+class DeltaKernelLogType : public LogType {
+public:
+    static constexpr const char *NAME = "DeltaKernel";
+    static constexpr LogLevel LEVEL = LogLevel::LOG_DEBUG; // WARNING: DeltaKernelLogType is special in that it overrides this base logtype
+
+    //! Construct the log types
+    DeltaKernelLogType();
+
+    static LogicalType GetLogType();
+
+    static string ConstructLogMessage(ffi::Event event);
+
+    // FIXME: HTTPLogType should be structured probably
+    static string ConstructLogMessage(const string &str) {
+        return str;
+    }
+};
+
+class DeltaFilterPushdownLogType : public LogType {
+public:
+    static constexpr const char *NAME = "DeltaFilterPushdown";
+    static constexpr LogLevel LEVEL = LogLevel::LOG_INFO; // WARNING: DeltaKernelLogType is special in that it overrides this base logtype
+
+    //! Construct the log types
+    DeltaFilterPushdownLogType();
+
+    static LogicalType GetLogType();
+
+    static string ConstructLogMessage(ffi::Event event);
+
+    // FIXME: HTTPLogType should be structured probably
+    static string ConstructLogMessage(const string &str) {
+        return str;
+    }
+};
+
+class DeltaLogTypes {
+public:
+    static void RegisterLogTypes(DatabaseInstance &instance) {
+        instance.GetLogManager().RegisterLogType(make_uniq<DeltaKernelLogType>());
+    }
+};
+
+} // namespace duckdb

--- a/test/sql/delta_kernel_rs/logging.test
+++ b/test/sql/delta_kernel_rs/logging.test
@@ -16,7 +16,7 @@ SELECT * FROM delta_scan('${DELTA_KERNEL_TESTS_PATH}/basic_partitioned')
 
 # No kernel logging available yet: we need to set delta_kernel_logging=true
 query I
-SELECT count(*) FROM duckdb_logs WHERE starts_with(type, 'delta.Kernel')
+SELECT count(*) FROM duckdb_logs WHERE type='DeltaKernel'
 ----
 0
 
@@ -31,9 +31,13 @@ SELECT * FROM delta_scan('${DELTA_KERNEL_TESTS_PATH}/basic_partitioned')
 
 # Now we have log!
 query I
-SELECT count(*) > 50 FROM duckdb_logs WHERE starts_with(type, 'delta.Kernel')
+SELECT count(*) > 50 FROM duckdb_logs WHERE type='DeltaKernel'
 ----
 true
+
+# The log can be automatically parsed into structured data
+statement ok
+select log_level, target, file, line from duckdb_logs_parsed('DeltaKernel')
 
 statement ok
 set delta_kernel_logging=true;

--- a/test/sql/generated/file_skipping_dynamic.test
+++ b/test/sql/generated/file_skipping_dynamic.test
@@ -30,7 +30,7 @@ constant	[]	['value2=102', 'value3=1002']	5	1
 
 # Clear logging storage
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # Try other column
 query IIII
@@ -48,7 +48,7 @@ constant	[]	['value3=1002']	5	1
 
 # Clear logging storage
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 ### Now we try dynamic pushdown
 query IIII
@@ -66,7 +66,7 @@ dynamic	[]	['value2=102']	5	1
 
 # Clear logging storage
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # Dynamic pushdown, other column
 query IIII
@@ -84,7 +84,7 @@ dynamic	[]	['value1=13']	5	1
 
 # Clear logging storage
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 ### Try partition column
 query IIII
@@ -103,7 +103,7 @@ dynamic	[]	['part=2']	5	5
 
 # Clear logging storage
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # Now let's get funky: a dynamic join filter plus a constant filter
 query IIII
@@ -124,7 +124,7 @@ dynamic	['value1=13']	['value1=13', 'value2=103']	1	1
 
 # Clear logging storage
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # Slightly weird case here: pushing down an identical dynamic filter and constant filter will make it show up twice with the second doing nothing
 query IIII
@@ -145,7 +145,7 @@ dynamic	['value1=13']	['value1=13 AND value1=13 AND value1=13']	1	1
 
 # Clear logging storage
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # Now we control the output of the filtered files by changing the delta_scan_explain_files_filtered setting
 statement ok

--- a/test/sql/generated/file_skipping_params.test
+++ b/test/sql/generated/file_skipping_params.test
@@ -29,7 +29,7 @@ constant
 dynamic
 
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # delta_scan: constant only filters
 query IIII
@@ -45,7 +45,7 @@ SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
 constant
 
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # delta_scan: dynamic only filters
 query IIII
@@ -61,7 +61,7 @@ SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
 dynamic
 
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # delta_scan: no filters
 query IIII
@@ -76,7 +76,7 @@ SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
 ----
 
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # attach: default = all filters
 statement ok
@@ -96,7 +96,7 @@ constant
 dynamic
 
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;
 
 # attach: pushdown mode can be configured
 statement ok
@@ -115,4 +115,4 @@ SELECT filter_type FROM delta_filter_pushdown_log() ORDER BY filter_type
 dynamic
 
 statement ok
-set enable_logging=false;set logging_storage='stdout';set logging_storage='memory';set enable_logging=true;
+pragma truncate_duckdb_logs;


### PR DESCRIPTION
Bumps to latest duckdb, applies changes to logging API by switching the kernel logging to structured logging.

I've left the filter pushdown logging as is, we can look into making a generalized version of that which iceberg can benefit from too later