### PR TITLE
Revert "Merge pull request #188 from samansmink/bump-kernel-to-0.10"

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,7 +20,7 @@ jobs:
       ci_tools_version: v1.2.2
       extension_name: delta
       enable_rust: true
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl;osx_amd64' # TODO re-enable osx_amd64
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
       extra_toolchains: 'python3'
 
   duckdb-stable-deploy:
@@ -32,5 +32,5 @@ jobs:
       extension_name: delta
       duckdb_version: v1.2.2
       ci_tools_version: v1.2.2
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl;osx_amd64' # TODO re-enable osx_amd64
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ ExternalProject_Add(
   # the c++ headers. Currently, when bumping the kernel version, the produced
   # header in ./src/include/delta_kernel_ffi.hpp should be also bumped, applying
   # the fix
-  GIT_TAG v0.10.0
+  GIT_TAG v0.8.0
   # Prints the env variables passed to the cargo build to the terminal, useful
   # in debugging because passing them through CMake is an error-prone mess
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${RUST_UNSET_ENV_VARS}

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -442,8 +442,9 @@ void ScanDataCallBack::VisitCallback(ffi::NullableCvoid engine_context, ffi::Ker
 	}
 }
 
-void ScanDataCallBack::VisitData(ffi::NullableCvoid engine_context, ffi::Handle<ffi::SharedScanMetadata> scan_metadata) {
-	ffi::visit_scan_metadata(scan_metadata, engine_context, VisitCallback);
+void ScanDataCallBack::VisitData(void *engine_context, ffi::ExclusiveEngineData *engine_data,
+                                 const struct ffi::KernelBoolSlice selection_vec, const ffi::CTransforms *transforms) {
+	ffi::visit_scan_data(engine_data, selection_vec, transforms, engine_context, VisitCallback);
 }
 
 DeltaMultiFileList::DeltaMultiFileList(ClientContext &context_p, const string &path)
@@ -522,7 +523,7 @@ string DeltaMultiFileList::GetFileInternal(idx_t i) const {
 
 	while (i >= resolved_files.size()) {
 		auto have_scan_data_res =
-		    ffi::scan_metadata_next(scan_data_iterator.get(), &callback_context, ScanDataCallBack::VisitData);
+		    ffi::kernel_scan_data_next(scan_data_iterator.get(), &callback_context, ScanDataCallBack::VisitData);
 
 		if (callback_context.error.HasError()) {
 			callback_context.error.Throw();
@@ -592,7 +593,7 @@ void DeltaMultiFileList::InitializeScan() const {
 	global_state = ffi::get_global_scan_state(scan.get());
 
 	// Create scan data iterator
-	scan_data_iterator = TryUnpackKernelResult(ffi::scan_metadata_iter_init(extern_engine.get(), scan.get()));
+	scan_data_iterator = TryUnpackKernelResult(ffi::kernel_scan_data_init(extern_engine.get(), scan.get()));
 
 	// Load partitions
 	auto partition_count = ffi::get_partition_column_count(snapshot_ref.GetPtr());

--- a/src/include/delta_kernel_ffi.hpp
+++ b/src/include/delta_kernel_ffi.hpp
@@ -61,7 +61,6 @@ enum class KernelError {
 	ChangeDataFeedUnsupported,
 	ChangeDataFeedIncompatibleSchema,
 	InvalidCheckpoint,
-	LiteralExpressionTransformError,
 };
 
 /// Definitions of level verbosity. Verbose Levels are "greater than" less verbose ones. So
@@ -108,14 +107,14 @@ enum class LogLineFormat {
 
 struct CStringMap;
 
-/// Transformation expressions that need to be applied to each row `i` in ScanMetadata. You can use
+/// Transformation expressions that need to be applied to each row `i` in ScanData. You can use
 /// [`get_transform_for_row`] to get the transform for a particular row. If that returns an
 /// associated expression, it _must_ be applied to the data read from the file specified by the
 /// row. The resultant schema for this expression is guaranteed to be `Scan.schema()`. If
 /// `get_transform_for_row` returns `NULL` no expression need be applied and the data read from disk
 /// is already in the correct logical state.
 ///
-/// NB: If you are using `visit_scan_metadata` you don't need to worry about dealing with probing
+/// NB: If you are using `visit_scan_data` you don't need to worry about dealing with probing
 /// `CTransforms`. The callback will be invoked with the correct transform for you.
 struct CTransforms;
 
@@ -130,8 +129,6 @@ struct EngineBuilder;
 /// an opaque struct that encapsulates data read by an engine. this handle can be passed back into
 /// some kernel calls to operate on the data, or can be converted into the raw data as read by the
 /// [`delta_kernel::Engine`] by calling [`get_raw_engine_data`]
-///
-/// [`get_raw_engine_data`]: crate::engine_data::get_raw_engine_data
 struct ExclusiveEngineData;
 
 struct ExclusiveFileReadResultIterator;
@@ -158,9 +155,7 @@ struct SharedGlobalScanState;
 
 struct SharedScan;
 
-struct SharedScanMetadata;
-
-struct SharedScanMetadataIterator;
+struct SharedScanDataIterator;
 
 struct SharedSchema;
 
@@ -207,14 +202,14 @@ struct KernelRowIndexArray {
 /// Additionally, in keeping with the [`Send`] contract, multi-threaded external code must
 /// enforce mutual exclusion -- no mutable handle should ever be passed to more than one kernel
 /// API call at a time. If thread races are possible, the handle should be protected with a
-/// mutex. Due to Rust [reference rules], this requirement applies even for API calls that
-/// appear to be read-only (because Rust code always receives the handle as mutable).
+/// mutex. Due to Rust [reference
+/// rules](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#the-rules-of-references),
+/// this requirement applies even for API calls that appear to be read-only (because Rust code
+/// always receives the handle as mutable).
 ///
 /// NOTE: Because the underlying type is always [`Sync`], multi-threaded external code can
 /// freely access shared (non-mutable) handles.
 ///
-/// [reference rules]:
-/// https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#the-rules-of-references
 template <typename H>
 using Handle = H *;
 
@@ -261,7 +256,7 @@ struct ExternResult {
 ///
 /// Whoever instantiates the struct must ensure it does not outlive the data it points to. The
 /// compiler cannot help us here, because raw pointers don't have lifetimes. A good rule of thumb is
-/// to always use the `kernel_string_slice` macro to create string slices, and to avoid returning
+/// to always use the [`kernel_string_slice`] macro to create string slices, and to avoid returning
 /// a string slice from a code block or function (since the move risks over-extending its lifetime):
 ///
 /// ```ignore
@@ -353,8 +348,6 @@ struct FileMeta {
 /// Model iterators. This allows an engine to specify iteration however it likes, and we simply wrap
 /// the engine functions. The engine retains ownership of the iterator.
 struct EngineIterator {
-	/// Opaque data that will be iterated over. This data will be passed to the get_next function
-	/// each time a next item is requested from the iterator
 	void *data;
 	/// A function that should advance the iterator and return the next time from the data
 	/// If the iterator is complete, it should return null. It should be safe to
@@ -365,11 +358,11 @@ struct EngineIterator {
 template <typename T>
 using VisitLiteralFn = void (*)(void *data, uintptr_t sibling_list_id, T value);
 
-using VisitJunctionFn = void (*)(void *data, uintptr_t sibling_list_id, uintptr_t child_list_id);
+using VisitVariadicFn = void (*)(void *data, uintptr_t sibling_list_id, uintptr_t child_list_id);
 
 using VisitUnaryFn = void (*)(void *data, uintptr_t sibling_list_id, uintptr_t child_list_id);
 
-using VisitBinaryFn = void (*)(void *data, uintptr_t sibling_list_id, uintptr_t child_list_id);
+using VisitBinaryOpFn = void (*)(void *data, uintptr_t sibling_list_id, uintptr_t child_list_id);
 
 /// The [`EngineExpressionVisitor`] defines a visitor system to allow engines to build their own
 /// representation of a kernel expression.
@@ -380,7 +373,7 @@ using VisitBinaryFn = void (*)(void *data, uintptr_t sibling_list_id, uintptr_t 
 /// future.
 ///
 /// Every expression the kernel visits belongs to some list of "sibling" elements. The schema
-/// itself is a list of schema elements, and every complex type (struct expression, array, junction, etc)
+/// itself is a list of schema elements, and every complex type (struct expression, array, variadic, etc)
 /// contains a list of "child" elements.
 ///  1. Before visiting any complex expression type, the kernel asks the engine to allocate a list to
 ///     hold its children
@@ -389,7 +382,7 @@ using VisitBinaryFn = void (*)(void *data, uintptr_t sibling_list_id, uintptr_t 
 ///      - For a struct literal, first visit each struct field and visit each value
 ///      - For a struct expression, visit each sub expression.
 ///      - For an array literal, visit each of the elements.
-///      - For a junction `and` or `or` expression, visit each sub-expression.
+///      - For a variadic `and` or `or` expression, visit each sub-expression.
 ///      - For a binary operator expression, visit the left and right operands.
 ///      - For a unary `is null` or `not` expression, visit the sub-expression.
 ///  3. When visiting a complex expression, the kernel also passes the "child list" containing
@@ -399,8 +392,8 @@ using VisitBinaryFn = void (*)(void *data, uintptr_t sibling_list_id, uintptr_t 
 /// WARNING: The visitor MUST NOT retain internal references to string slices or binary data passed
 /// to visitor methods
 /// TODO: Visit type information in struct field and null. This will likely involve using the schema
-/// visitor. Note that struct literals are currently in flux, and may change significantly. Here is
-/// the relevant issue: <https://github.com/delta-io/delta-kernel-rs/issues/412>
+/// visitor. Note that struct literals are currently in flux, and may change significantly. Here is the relevant
+/// issue: https://github.com/delta-io/delta-kernel-rs/issues/412
 struct EngineExpressionVisitor {
 	/// An opaque engine state pointer
 	void *data;
@@ -451,10 +444,10 @@ struct EngineExpressionVisitor {
 	void (*visit_literal_null)(void *data, uintptr_t sibling_list_id);
 	/// Visits an `and` expression belonging to the list identified by `sibling_list_id`.
 	/// The sub-expressions of the array are in a list identified by `child_list_id`
-	VisitJunctionFn visit_and;
+	VisitVariadicFn visit_and;
 	/// Visits an `or` expression belonging to the list identified by `sibling_list_id`.
 	/// The sub-expressions of the array are in a list identified by `child_list_id`
-	VisitJunctionFn visit_or;
+	VisitVariadicFn visit_or;
 	/// Visits a `not` expression belonging to the list identified by `sibling_list_id`.
 	/// The sub-expression will be in a _one_ item list identified by `child_list_id`
 	VisitUnaryFn visit_not;
@@ -463,43 +456,43 @@ struct EngineExpressionVisitor {
 	VisitUnaryFn visit_is_null;
 	/// Visits the `LessThan` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_lt;
+	VisitBinaryOpFn visit_lt;
 	/// Visits the `LessThanOrEqual` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_le;
+	VisitBinaryOpFn visit_le;
 	/// Visits the `GreaterThan` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_gt;
+	VisitBinaryOpFn visit_gt;
 	/// Visits the `GreaterThanOrEqual` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_ge;
+	VisitBinaryOpFn visit_ge;
 	/// Visits the `Equal` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_eq;
+	VisitBinaryOpFn visit_eq;
 	/// Visits the `NotEqual` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_ne;
+	VisitBinaryOpFn visit_ne;
 	/// Visits the `Distinct` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_distinct;
+	VisitBinaryOpFn visit_distinct;
 	/// Visits the `In` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_in;
+	VisitBinaryOpFn visit_in;
 	/// Visits the `NotIn` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_not_in;
+	VisitBinaryOpFn visit_not_in;
 	/// Visits the `Add` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_add;
+	VisitBinaryOpFn visit_add;
 	/// Visits the `Minus` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_minus;
+	VisitBinaryOpFn visit_minus;
 	/// Visits the `Multiply` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_multiply;
+	VisitBinaryOpFn visit_multiply;
 	/// Visits the `Divide` binary operator belonging to the list identified by `sibling_list_id`.
 	/// The operands will be in a _two_ item list identified by `child_list_id`
-	VisitBinaryFn visit_divide;
+	VisitBinaryOpFn visit_divide;
 	/// Visits the `column` belonging to the list identified by `sibling_list_id`.
 	void (*visit_column)(void *data, uintptr_t sibling_list_id, KernelStringSlice name);
 	/// Visits a `StructExpression` belonging to the list identified by `sibling_list_id`.
@@ -516,7 +509,7 @@ struct im_an_unused_struct_that_tricks_msvc_into_compilation {
 	ExternResult<Handle<SharedSnapshot>> field5;
 	ExternResult<uintptr_t> field6;
 	ExternResult<ArrowFFIData *> field7;
-	ExternResult<Handle<SharedScanMetadataIterator>> field8;
+	ExternResult<Handle<SharedScanDataIterator>> field8;
 	ExternResult<Handle<SharedScan>> field9;
 	ExternResult<Handle<ExclusiveFileReadResultIterator>> field10;
 	ExternResult<KernelRowIndexArray> field11;
@@ -546,14 +539,12 @@ using TracingLogLineFn = void (*)(KernelStringSlice line);
 ///
 /// When invoking [`scan::scan`], The engine provides a pointer to the (engine's native) predicate,
 /// along with a visitor function that can be invoked to recursively visit the predicate. This
-/// engine state must be valid until the call to [`scan::scan`] returns. Inside that method, the
+/// engine state must be valid until the call to `scan::scan` returns. Inside that method, the
 /// kernel allocates visitor state, which becomes the second argument to the predicate visitor
 /// invocation along with the engine-provided predicate pointer. The visitor state is valid for the
 /// lifetime of the predicate visitor invocation. Thanks to this double indirection, engine and
 /// kernel each retain ownership of their respective objects, with no need to coordinate memory
 /// lifetimes with the other.
-///
-/// [`scan::scan`]: crate::scan::scan
 struct EnginePredicate {
 	void *predicate;
 	uintptr_t (*visitor)(void *predicate, KernelExpressionVisitorState *state);
@@ -576,7 +567,7 @@ struct Stats {
 /// * `size`: an `i64` which is the size of the file
 /// * `dv_info`: a [`DvInfo`] struct, which allows getting the selection vector for this file
 /// * `transform`: An optional expression that, if not `NULL`, _must_ be applied to physical data to
-///   convert it to the correct logical format. If this is `NULL`, no transform is needed.
+///                convert it to the correct logical format. If this is `NULL`, no transform is needed.
 /// * `partition_values`: [DEPRECATED] a `HashMap<String, String>` which are partition values
 using CScanCallback = void (*)(NullableCvoid engine_context, KernelStringSlice path, int64_t size, const Stats *stats,
                                const DvInfo *dv_info, const Expression *transform, const CStringMap *partition_map);
@@ -788,11 +779,8 @@ Handle<StringSliceIterator> get_partition_columns(Handle<SharedSnapshot> snapsho
 
 /// # Safety
 ///
-/// The iterator must be valid (returned by [`scan_metadata_iter_init`]) and not yet freed by
-/// [`free_scan_metadata_iter`]. The visitor function pointer must be non-null.
-///
-/// [`scan_metadata_iter_init`]: crate::scan::scan_metadata_iter_init
-/// [`free_scan_metadata_iter`]: crate::scan::free_scan_metadata_iter
+/// The iterator must be valid (returned by [kernel_scan_data_init]) and not yet freed by
+/// [kernel_scan_data_free]. The visitor function pointer must be non-null.
 bool string_slice_next(Handle<StringSliceIterator> data, NullableCvoid engine_context,
                        void (*engine_visitor)(NullableCvoid engine_context, KernelStringSlice slice));
 
@@ -836,8 +824,6 @@ ExternResult<ArrowFFIData *> get_raw_arrow_data(Handle<ExclusiveEngineData> data
 ///
 /// The iterator must be valid (returned by [`read_parquet_file`]) and not yet freed by
 /// [`free_read_result_iter`]. The visitor function pointer must be non-null.
-///
-/// [`free_engine_data`]: crate::free_engine_data
 ExternResult<bool> read_result_next(Handle<ExclusiveFileReadResultIterator> data, NullableCvoid engine_context,
                                     void (*engine_visitor)(NullableCvoid engine_context,
                                                            Handle<ExclusiveEngineData> engine_data));
@@ -856,20 +842,18 @@ void free_read_result_iter(Handle<ExclusiveFileReadResultIterator> data);
 ExternResult<Handle<ExclusiveFileReadResultIterator>>
 read_parquet_file(Handle<SharedExternEngine> engine, const FileMeta *file, Handle<SharedSchema> physical_schema);
 
-/// Creates a new expression evaluator as provided by the passed engines `EvaluationHandler`.
+/// Get the evaluator as provided by the passed engines `ExpressionHandler`.
 ///
 /// # Safety
 /// Caller is responsible for calling with a valid `Engine`, `Expression`, and `SharedSchema`s
-Handle<SharedExpressionEvaluator> new_expression_evaluator(Handle<SharedExternEngine> engine,
-                                                           Handle<SharedSchema> input_schema,
-                                                           const Expression *expression,
-                                                           Handle<SharedSchema> output_type);
+Handle<SharedExpressionEvaluator> get_evaluator(Handle<SharedExternEngine> engine, Handle<SharedSchema> input_schema,
+                                                const Expression *expression, Handle<SharedSchema> output_type);
 
-/// Free an expression evaluator
+/// Free an evaluator
 /// # Safety
 ///
 /// Caller is responsible for passing a valid handle.
-void free_expression_evaluator(Handle<SharedExpressionEvaluator> evaluator);
+void free_evaluator(Handle<SharedExpressionEvaluator> evaluator);
 
 /// Use the passed `evaluator` to evaluate its expression against the passed `batch` data.
 ///
@@ -1016,24 +1000,9 @@ bool enable_log_line_tracing(TracingLogLineFn callback, Level max_level);
 bool enable_formatted_log_line_tracing(TracingLogLineFn callback, Level max_level, LogLineFormat format, bool ansi,
                                        bool with_time, bool with_level, bool with_target);
 
-/// Drop a `SharedScanMetadata`.
-///
-/// # Safety
-///
-/// Caller is responsible for passing a valid scan data handle.
-void free_scan_metadata(Handle<SharedScanMetadata> scan_metadata);
-
-/// Get a selection vector out of a [`SharedScanMetadata`] struct
-///
-/// # Safety
-/// Engine is responsible for providing valid pointers for each argument
-ExternResult<KernelBoolSlice> selection_vector_from_scan_metadata(Handle<SharedScanMetadata> scan_metadata,
-                                                                  Handle<SharedExternEngine> engine);
-
 /// Drops a scan.
-///
 /// # Safety
-/// Caller is responsible for passing a valid scan handle.
+/// Caller is responsible for passing a [valid][Handle#Validity] scan handle.
 void free_scan(Handle<SharedScan> scan);
 
 /// Get a [`Scan`] over the table specified by the passed snapshot. It is the responsibility of the
@@ -1072,36 +1041,33 @@ Handle<SharedSchema> get_global_logical_schema(Handle<SharedGlobalScanState> sta
 void free_global_scan_state(Handle<SharedGlobalScanState> state);
 
 /// Get an iterator over the data needed to perform a scan. This will return a
-/// [`ScanMetadataIterator`] which can be passed to [`scan_metadata_next`] to get the
-/// actual data in the iterator.
+/// [`KernelScanDataIterator`] which can be passed to [`kernel_scan_data_next`] to get the actual
+/// data in the iterator.
 ///
 /// # Safety
 ///
 /// Engine is responsible for passing a valid [`SharedExternEngine`] and [`SharedScan`]
-ExternResult<Handle<SharedScanMetadataIterator>> scan_metadata_iter_init(Handle<SharedExternEngine> engine,
-                                                                         Handle<SharedScan> scan);
+ExternResult<Handle<SharedScanDataIterator>> kernel_scan_data_init(Handle<SharedExternEngine> engine,
+                                                                   Handle<SharedScan> scan);
 
-/// Call the provided `engine_visitor` on the next scan metadata item. The visitor will be provided with
-/// a [`SharedScanMetadata`], which contains the actual scan files and the associated selection vector. It is the
-/// responsibility of the _engine_ to free the associated resources after use by calling
-/// [`free_engine_data`] and [`free_bool_slice`] respectively.
+/// Call the provided `engine_visitor` on the next scan data item. The visitor will be provided with
+/// a selection vector and engine data. It is the responsibility of the _engine_ to free these when
+/// it is finished by calling [`free_bool_slice`] and [`free_engine_data`] respectively.
 ///
 /// # Safety
 ///
-/// The iterator must be valid (returned by [scan_metadata_iter_init]) and not yet freed by
-/// [`free_scan_metadata_iter`]. The visitor function pointer must be non-null.
-///
-/// [`free_bool_slice`]: crate::free_bool_slice
-/// [`free_engine_data`]: crate::free_engine_data
-ExternResult<bool> scan_metadata_next(Handle<SharedScanMetadataIterator> data, NullableCvoid engine_context,
-                                      void (*engine_visitor)(NullableCvoid engine_context,
-                                                             Handle<SharedScanMetadata> scan_metadata));
+/// The iterator must be valid (returned by [kernel_scan_data_init]) and not yet freed by
+/// [`free_kernel_scan_data`]. The visitor function pointer must be non-null.
+ExternResult<bool>
+kernel_scan_data_next(Handle<SharedScanDataIterator> data, NullableCvoid engine_context,
+                      void (*engine_visitor)(NullableCvoid engine_context, Handle<ExclusiveEngineData> engine_data,
+                                             KernelBoolSlice selection_vector, const CTransforms *transforms));
 
 /// # Safety
 ///
 /// Caller is responsible for (at most once) passing a valid pointer returned by a call to
-/// [`scan_metadata_iter_init`].
-void free_scan_metadata_iter(Handle<SharedScanMetadataIterator> data);
+/// [`kernel_scan_data_init`].
+void free_kernel_scan_data(Handle<SharedScanDataIterator> data);
 
 /// allow probing into a CStringMap. If the specified key is in the map, kernel will call
 /// allocate_fn with the value associated with the key and return the value returned from that
@@ -1120,6 +1086,8 @@ NullableCvoid get_from_string_map(const CStringMap *map, KernelStringSlice key, 
 ///
 /// The engine is responsible for providing a valid [`CTransforms`] pointer, and for checking if the
 /// return value is `NULL` or not.
+/// TODO: this Option is problematic because its an incomplete type which prevents us from using the
+/// im_an_unused_struct_that_tricks_msvc_into_compilation trick
 // Option<Handle<SharedExpression>> get_transform_for_row(uintptr_t row, const CTransforms *transforms);
 
 /// Get a selection vector out of a [`DvInfo`] struct
@@ -1136,13 +1104,13 @@ ExternResult<KernelBoolSlice> selection_vector_from_dv(const DvInfo *dv_info, Ha
 ExternResult<KernelRowIndexArray> row_indexes_from_dv(const DvInfo *dv_info, Handle<SharedExternEngine> engine,
                                                       Handle<SharedGlobalScanState> state);
 
-/// Shim for ffi to call visit_scan_metadata. This will generally be called when iterating through scan
-/// data which provides the [`SharedScanMetadata`] as each element in the iterator.
+/// Shim for ffi to call visit_scan_data. This will generally be called when iterating through scan
+/// data which provides the data handle and selection vector as each element in the iterator.
 ///
 /// # Safety
-/// engine is responsible for passing a valid [`SharedScanMetadata`].
-void visit_scan_metadata(Handle<SharedScanMetadata> scan_metadata, NullableCvoid engine_context,
-                         CScanCallback callback);
+/// engine is responsible for passing a valid [`ExclusiveEngineData`] and selection vector.
+void visit_scan_data(Handle<ExclusiveEngineData> data, KernelBoolSlice selection_vec, const CTransforms *transforms,
+                     NullableCvoid engine_context, CScanCallback callback);
 
 /// Visit the given `schema` using the provided `visitor`. See the documentation of
 /// [`EngineSchemaVisitor`] for a description of how this visitor works.

--- a/src/include/delta_utils.hpp
+++ b/src/include/delta_utils.hpp
@@ -70,15 +70,15 @@ private:
 	static void VisitIsNullExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id);
 
 	template <ExpressionType EXPRESSION_TYPE, typename EXPRESSION_TYPENAME>
-	static ffi::VisitJunctionFn VisitUnaryExpression() {
+	static ffi::VisitVariadicFn VisitUnaryExpression() {
 		return &VisitVariadicExpression<EXPRESSION_TYPE, EXPRESSION_TYPENAME>;
 	}
 	template <ExpressionType EXPRESSION_TYPE, typename EXPRESSION_TYPENAME>
-	static ffi::VisitJunctionFn VisitBinaryExpression() {
+	static ffi::VisitVariadicFn VisitBinaryExpression() {
 		return &VisitBinaryExpression<EXPRESSION_TYPE, EXPRESSION_TYPENAME>;
 	}
 	template <ExpressionType EXPRESSION_TYPE, typename EXPRESSION_TYPENAME>
-	static ffi::VisitJunctionFn VisitVariadicExpression() {
+	static ffi::VisitVariadicFn VisitVariadicExpression() {
 		return &VisitVariadicExpression<EXPRESSION_TYPE, EXPRESSION_TYPENAME>;
 	}
 
@@ -238,7 +238,7 @@ typedef TemplatedUniqueKernelPointer<ffi::SharedSnapshot, ffi::free_snapshot> Ke
 typedef TemplatedUniqueKernelPointer<ffi::SharedExternEngine, ffi::free_engine> KernelExternEngine;
 typedef TemplatedUniqueKernelPointer<ffi::SharedScan, ffi::free_scan> KernelScan;
 typedef TemplatedUniqueKernelPointer<ffi::SharedGlobalScanState, ffi::free_global_scan_state> KernelGlobalScanState;
-typedef TemplatedUniqueKernelPointer<ffi::SharedScanMetadataIterator, ffi::free_scan_metadata_iter> KernelScanDataIterator;
+typedef TemplatedUniqueKernelPointer<ffi::SharedScanDataIterator, ffi::free_kernel_scan_data> KernelScanDataIterator;
 
 template <typename KernelType, void (*DeleteFunction)(KernelType *)>
 struct SharedKernelPointer;

--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
@@ -135,7 +135,9 @@ protected:
 struct ScanDataCallBack {
 	explicit ScanDataCallBack(const DeltaMultiFileList &snapshot_p) : snapshot(snapshot_p) {
 	}
-    static void VisitData(ffi::NullableCvoid engine_context, ffi::Handle<ffi::SharedScanMetadata> scan_metadata);
+
+	static void VisitData(void *engine_context, ffi::ExclusiveEngineData *engine_data,
+	                      const struct ffi::KernelBoolSlice selection_vec, const ffi::CTransforms *transforms);
 	static void VisitCallback(ffi::NullableCvoid engine_context, struct ffi::KernelStringSlice path, int64_t size,
 	                          const ffi::Stats *stats, const ffi::DvInfo *dv_info, const ffi::Expression *transform,
 	                          const struct ffi::CStringMap *partition_values);

--- a/test/sql/generated/file_skipping_all_types.test
+++ b/test/sql/generated/file_skipping_all_types.test
@@ -31,12 +31,13 @@ WHERE
 ----
 3.0	3.0	3.0
 
+# FIXME: Partition columns currently don't cause file skipping yet
 query II
 EXPLAIN ANALYZE SELECT part
 FROM delta_scan('./data/generated/test_file_skipping/${type}/delta_lake')
 WHERE part > 0.5
 ----
-analyzed_plan	<REGEX>:.* Scanning Files: 4/5.*
+analyzed_plan	<REGEX>:.* Scanning Files: 5/5.*
 
 endloop
 
@@ -48,12 +49,13 @@ WHERE value1=false
 ----
 analyzed_plan	<REGEX>:.*File Filters:.*value1=false.*Scanning Files: 1/2.*
 
+# FIXME: Partition columns currently don't cause file skipping yet
 query II
 EXPLAIN ANALYZE SELECT part
 FROM delta_scan('./data/generated/test_file_skipping/bool/delta_lake')
 WHERE part=false
 ----
-analyzed_plan	<REGEX>:.* Scanning Files: 1/2.*
+analyzed_plan	<REGEX>:.* Scanning Files: 2/2.*
 
 foreach type int tinyint smallint bigint
 
@@ -78,12 +80,13 @@ WHERE
 ----
 3	3	3
 
+# FIXME: Partition columns currently don't cause file skipping yet
 query II
 EXPLAIN ANALYZE SELECT part
 FROM delta_scan('./data/generated/test_file_skipping/${type}/delta_lake')
 WHERE part = 0
 ----
-analyzed_plan	<REGEX>:.* Scanning Files: 1/5.*
+analyzed_plan	<REGEX>:.* Scanning Files: 5/5.*
 
 endloop
 
@@ -108,12 +111,13 @@ WHERE
 ----
 2	2	2
 
+# FIXME: Partition columns currently don't cause file skipping yet
 query II
 EXPLAIN ANALYZE SELECT part
 FROM delta_scan('./data/generated/test_file_skipping/varchar/delta_lake')
 WHERE part = '0'
 ----
-analyzed_plan	<REGEX>:.* Scanning Files: 1/5.*
+analyzed_plan	<REGEX>:.* Scanning Files: 5/5.*
 
 # We can remove this from output if precise operator timing is crucial
 statement ok

--- a/test/sql/generated/file_skipping_dynamic.test
+++ b/test/sql/generated/file_skipping_dynamic.test
@@ -94,11 +94,12 @@ WHERE part = (SELECT 2)
 ----
 12	1002	102	2
 
+# FIXME: the above query does not yet support pushdown because kernel can't do pushdown on partition columns
 query IIIII
 SELECT filter_type, filters_before, filters_after, files_before, files_after
 FROM delta_filter_pushdown_log()
 ----
-dynamic	[]	[part=2]	5	1
+dynamic	[]	[part=2]	5	5
 
 # Clear logging storage
 statement ok

--- a/test/sql/main/test_error_messages.test
+++ b/test/sql/main/test_error_messages.test
@@ -33,7 +33,7 @@ CREATE SECRET s1 (
 statement error
 FROM delta_scan('s3://bucket/doesnt/exist/either');
 ----
-IO Error: DeltKernel ObjectStoreError (8): Error interacting with object store: Generic S3 error: Error performing GET
+IO Error: DeltKernel ObjectStoreError (8): Error interacting with object store: Generic S3 error: Error after
 
 statement error
 FROM delta_scan('duck://bucket/doesnt/exist/either');
@@ -46,4 +46,4 @@ ATTACH 's3://bucket/doesnt/exist/either' AS s1 (TYPE delta);
 statement error
 SHOW ALL TABLES;
 ----
-IO Error: DeltKernel ObjectStoreError (8): Error interacting with object store: Generic S3 error: Error performing GET
+IO Error: DeltKernel ObjectStoreError (8): Error interacting with object store: Generic S3 error: Error after

--- a/test/sql/main/test_expression.test
+++ b/test/sql/main/test_expression.test
@@ -26,7 +26,7 @@ false
 '1970-01-01 00:00:00.0001'::TIMESTAMP
 '1970-02-02'::DATE
 '\x00\x00\xDE\xAD\xBE\xEF\xCA\xFE'::BLOB
-18446744073709551.617
+0.001
 NULL
 struct_pack("'top'" := struct_pack("'a'" := 500, "'b'" := list_value(5, 0)))
 list_value(5, 0)


### PR DESCRIPTION
The bump to kernel v0.10.0 in https://github.com/duckdb/duckdb-delta/pull/188 has unfortunately introduced issues such as:

-  https://github.com/duckdb/duckdb-delta/issues/189
    - fixed upstream already in https://github.com/delta-io/delta-kernel-rs/pull/960, to be released in kernel v0.11.0
- https://github.com/duckdb/duckdb-delta/issues/191

Therefore, to have a functioning delta extension for the upcoming duckdb v1.3.0 release, I will revert this PR for now.

Note that I will re-apply these changes later to have them available in the nightly release of delta.