### PR TITLE
add NOT_EQUAL pushdown

### DIFF
--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -750,6 +750,14 @@ uintptr_t PredicateVisitor::VisitConstantFilter(const string &col_name, const Co
 		}
 		break;
 	}
+	// TODO: implement these types
+	case LogicalTypeId::STRUCT:
+	case LogicalTypeId::MAP:
+	case LogicalTypeId::LIST:
+	case LogicalTypeId::TIMESTAMP:
+	case LogicalTypeId::TIMESTAMP_TZ:
+	case LogicalTypeId::DATE:
+	case LogicalTypeId::DECIMAL:
 	default:
 		break; // unsupported type
 	}
@@ -766,7 +774,15 @@ uintptr_t PredicateVisitor::VisitConstantFilter(const string &col_name, const Co
 		return visit_predicate_ge(state, left, right);
 	case ExpressionType::COMPARE_EQUAL:
 		return visit_predicate_eq(state, left, right);
-
+    case ExpressionType::COMPARE_NOTEQUAL:
+	    return ffi::visit_predicate_ne(state, left, right);
+	// TODO: evaluate for implementation
+	case ExpressionType::COMPARE_BETWEEN:
+	case ExpressionType::COMPARE_NOT_BETWEEN:
+	case ExpressionType::COMPARE_NOT_IN:
+	case ExpressionType::COMPARE_IN:
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
 	default:
 		// TODO: add more types
 		return ~0; // Unsupported operation
@@ -817,6 +833,17 @@ uintptr_t PredicateVisitor::VisitFilter(const string &col_name, const TableFilte
 		return VisitIsNull(col_name, state);
 	case TableFilterType::IS_NOT_NULL:
 		return VisitIsNotNull(col_name, state);
+	// TODO: implement once kernel can do arbitrary expressions
+	case TableFilterType::EXPRESSION_FILTER:
+    // TODO: implement once kernel adds support for IN filters / arbitrary expressions
+	case TableFilterType::IN_FILTER:
+    // TODO: implement once kernel can do struct extract pushdown / arbitrary expressions
+    case TableFilterType::STRUCT_EXTRACT:
+    // TODO: figure out if this is ever useful
+	case TableFilterType::DYNAMIC_FILTER:
+	// TODO: can we even push these down?
+	case TableFilterType::CONJUNCTION_OR:
+	case TableFilterType::OPTIONAL_FILTER:
 	default:
 		return ~0;
 	}

--- a/test/sql/generated/file_skipping_all_types.test
+++ b/test/sql/generated/file_skipping_all_types.test
@@ -115,6 +115,126 @@ WHERE part = '0'
 ----
 analyzed_plan	<REGEX>:.* Scanning Files: 1/5.*
 
+# TODO test remaining types:
+# - STRUCT
+# - MAP
+# - LIST
+# - TIMESTAMP
+# - TIMESTAMP_TZ
+# - DATE
+# - DECIMAL
+
+### Now test all Comparators are fileskipping
+
+# test: '>'
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part > 2
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 2/5.*
+
+# test: '<'
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part < 2
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 2/5.*
+
+# test: '<='
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part <= 2
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 3/5.*
+
+# test: '>='
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part >= 2
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 3/5.*
+
+# test: '='
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part = 2
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 1/5.*
+
+# test: '!='
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part != 2
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 4/5.*
+
+# test: 'BETWEEN'
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part between 2 and 4
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 3/5.*
+
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part = 2 OR part = 4
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 2/5.*
+
+# TODO: fix unsupported comparators
+mode skip
+
+# test: 'NOT BETWEEN' 
+# NOTE: requires 
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part not between 2 and 4
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 2/5.*
+
+# test: 'IN'
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part in [2, 3]
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 2/5.*
+
+# test: 'NOT IN'
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part not in [2, 3]
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 3/5.*
+
+# IS DISTINCT FROM 
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part is distinct from null
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 0/5.*
+
+# IS NOT DISTINCT FROM 
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/int/delta_lake')
+WHERE part is not distinct from null
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 5/5.*
+
+mode unskip
+
 # We can remove this from output if precise operator timing is crucial
 statement ok
 set delta_scan_explain_files_filtered = false;


### PR DESCRIPTION
Also adds a bit more testing and an exhaustive list of todo's of things yet to be implemented. All of them are currently blocked by kernel ffi work, except for:
- OR filters: I will follow up with another PR to implement those
- Expression filters: we should discuss with the delta kernel peeps how to do this generically. We could consider parsing the arbitrary expression filters such that we can at least support filters that duckdb transforms into them like `NOT BETWEEN`