### PR TITLE
Set `downgrade_aws_cli` option to enable uploading to vcpkg cache

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,12 +17,15 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     secrets: inherit
     with:
+      # Main config
       duckdb_version: v1.3.0
       ci_tools_version: main
       extension_name: delta
       enable_rust: true
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
-      extra_toolchains: 'python3'
+
+      # Config to write vcpkg binary cache
+      extra_toolchains: ${{ github.event_name != 'pull_request' && ';downgrade_aws_cli;' || '' }}
       save_cache: ${{ github.event_name != 'pull_request' }}
       vcpkg_binary_sources: ${{ github.event_name != 'pull_request' && vars.VCPKG_BINARY_SOURCES || '' }}
 

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -15,7 +15,7 @@ jobs:
   duckdb-stable-build:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
-    secrets: inherit
+    secrets: inherit # required for writing to vcpkg binary cache
     with:
       # Main config
       duckdb_version: v1.3.0
@@ -25,7 +25,7 @@ jobs:
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl'
 
       # Config to write vcpkg binary cache
-      extra_toolchains: ${{ github.event_name != 'pull_request' && ';downgrade_aws_cli;' || '' }}
+      extra_toolchains: ${{ github.event_name != 'pull_request' && ';downgrade_aws_cli;python3;' || 'python3' }}
       save_cache: ${{ github.event_name != 'pull_request' }}
       vcpkg_binary_sources: ${{ github.event_name != 'pull_request' && vars.VCPKG_BINARY_SOURCES || '' }}
 


### PR DESCRIPTION
Workaround to fix uploads to our r2 based cache, see https://github.com/duckdb/extension-ci-tools/pull/212