### PR TITLE
Use `delete` for pointer allocated with `new`

### DIFF
--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -690,7 +690,7 @@ void DeltaMultiFileList::InitializeScan() const {
 	    return test;
 	});
     root_path = *static_cast<string*>(ptr);
-    free(ptr);
+    delete ptr;
 
 	// Create scan data iterator
 	scan_data_iterator = TryUnpackKernelResult(ffi::scan_metadata_iter_init(extern_engine.get(), scan.get()));


### PR DESCRIPTION
There is undefined behavior in the `DeltaMultiFileList::InitializeScan` function.
[`scan_table_root`](https://github.com/delta-io/delta-kernel-rs/blob/bbca6261fbfe6d9aaf9bc3f6ad219b8279b76a7a/ffi/src/scan.rs#L126) returns the pointer allocated by `allocate_fn`, and in the case of `InitializeScan`, it is using `new`.

https://github.com/duckdb/duckdb-delta/blob/4bd160a5ac4a4168bc27aace49ede0a3cdc7ad5b/src/functions/delta_scan/delta_multi_file_list.cpp#L688

Therefore, `ptr` must be deallocated using `delete` instead of `free`.

---

This fixes the following error when running the _basic_append.test_ SQLLogic test:
> pointer being freed was not allocated