### PR TITLE
feat: respect null constraints on inserts

### DIFF
--- a/scripts/data_generator/pyspark_generator/__init__.py
+++ b/scripts/data_generator/pyspark_generator/__init__.py
@@ -51,7 +51,7 @@ def generate_test_data_pyspark(base_path, name, current_path, input_path, delete
         spark.sql(f"ALTER TABLE test_table_{name} SET TBLPROPERTIES ('delta.minReaderVersion' = '3', 'delta.minWriterVersion' = '7');")
 
 
-    ## CREATE
+        ## CREATE
         ## CONFIGURE USAGE OF DELETION VECTORS
         if (delete_predicate):
             spark.sql(f"ALTER TABLE test_table_{name} SET TBLPROPERTIES ('delta.enableDeletionVectors' = true);")

--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
@@ -13,6 +13,7 @@
 
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
 #include "duckdb/common/multi_file/multi_file_data.hpp"
+#include "duckdb/parser/constraints/not_null_constraint.hpp"
 
 namespace duckdb {
 
@@ -37,6 +38,16 @@ struct DeltaFileMetaData {
 	case_insensitive_map_t<Value> partition_map;
 
 	unique_ptr<vector<unique_ptr<ParsedExpression>>> transform_expression;
+};
+
+// Constraint only for internal delta extension use
+// Todo: refactor to use duckdb constraint classes, updating the DuckDB side NotNullConstraint
+class NestedNotNullConstraint{
+public:
+    explicit NestedNotNullConstraint(LogicalIndex index_p, string path_p) : index(index_p), path(path_p)  {
+    }
+    LogicalIndex index;
+    string path;
 };
 
 //! The DeltaMultiFileList implements the MultiFileList API to allow injecting it into the regular DuckDB parquet scan
@@ -72,6 +83,8 @@ public:
 	vector<string> GetPartitionColumns();
 
 	vector<MultiFileColumnDefinition> &GetLazyLoadedGlobalColumns() const;
+    vector<NestedNotNullConstraint> GetNestedNotNullConstraints() const;
+    bool HasNullConstraintsInArrays() const;
 
     bool VariantEnabled() {
         return enable_variant;
@@ -137,9 +150,12 @@ protected:
 	mutable vector<OpenFileInfo> resolved_files;
 	mutable TableFilterSet table_filters;
 
-	//! Names
-	vector<string> names;
+    mutable vector<NestedNotNullConstraint> not_null_constraints;
+    mutable bool has_null_constraints_in_arrays = false;
+
 	vector<LogicalType> types;
+    //! Names
+    vector<string> names;
 
 	bool have_bound = false;
 

--- a/src/include/storage/delta_table_entry.hpp
+++ b/src/include/storage/delta_table_entry.hpp
@@ -8,11 +8,14 @@
 
 #pragma once
 
+#include <duckdb/parser/constraints/not_null_constraint.hpp>
+
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 
 namespace duckdb {
 class DeltaMultiFileList;
+class NestedNotNullConstraint;
 
 class DeltaTableEntry : public TableCatalogEntry {
 public:
@@ -29,6 +32,9 @@ public:
 
 	void BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj, LogicalUpdate &update,
 	                           ClientContext &context) override;
+
+    case_insensitive_map_t<vector<NestedNotNullConstraint>> GetNotNullConstraints() const;
+    void ThrowOnUnsupportedFieldForInserting() const;
 
 public:
 	shared_ptr<DeltaMultiFileList> snapshot;

--- a/src/storage/delta_schema_entry.cpp
+++ b/src/storage/delta_schema_entry.cpp
@@ -111,11 +111,17 @@ unique_ptr<DeltaTableEntry> DeltaSchemaEntry::CreateTableEntry(ClientContext &co
 	vector<string> names;
 	snapshot->Bind(return_types, names);
 
+    // TODO: forward nullability constraints
+
 	CreateTableInfo table_info;
 	for (idx_t i = 0; i < return_types.size(); i++) {
 		table_info.columns.AddColumn(ColumnDefinition(names[i], return_types[i]));
 	}
 	table_info.table = delta_catalog.GetName();
+
+    // Copy over constraints to table info TODO: these are incompatible currently
+    // table_info.constraints = snapshot->not_null_constraints;}
+
 	auto table_entry = make_uniq<DeltaTableEntry>(delta_catalog, *this, table_info);
 	table_entry->snapshot = std::move(snapshot);
 

--- a/test/sql/main/writing/non_nullable.test
+++ b/test/sql/main/writing/non_nullable.test
@@ -1,0 +1,81 @@
+# name: test/sql/main/writing/basic_append.test
+# description: test appending to some generated tables
+
+require parquet
+
+require delta
+
+# Copy test data over to tmp test dir because we'll be inserting stuff
+statement ok
+from copy_dir('data/inlined/null_constraints_lists', '__TEST_DIR__/non_nullable/null_constraints_lists');
+from copy_dir('data/inlined/null_constraints_structs', '__TEST_DIR__/non_nullable/null_constraints_structs');
+
+statement ok
+ATTACH '__TEST_DIR__/non_nullable/null_constraints_structs/delta_lake' AS delta_table (TYPE delta);
+
+query I
+select count(*)  FROM delta_table;
+----
+10
+
+# top level primitive type column is null
+statement error
+INSERT INTO delta_table VALUES (NULL, {'value': 1}, {'value': {'a': 1, 'b': 1}});
+----
+Constraint Error: NOT NULL constraint failed: delta_table.i
+
+# top level struct column is null
+statement error
+INSERT INTO delta_table VALUES (1, NULL, {'value': {'a': 1, 'b': 1}});
+----
+Constraint Error: NOT NULL constraint failed: delta_table.struct
+
+# struct column field is null
+statement error
+INSERT INTO delta_table VALUES (1, {'value': NULL}, {'value': {'a': 1, 'b': 1}});
+----
+Constraint Error: NOT NULL constraint failed: delta_table.struct.value
+
+# nested struct field is null
+statement error
+INSERT INTO delta_table VALUES (1, {'value': 1}, {'value': NULL});
+----
+Constraint Error: NOT NULL constraint failed: delta_table.nested_struct.value
+
+# nested struct inner field is null
+statement error
+INSERT INTO delta_table VALUES (1, {'value': 1}, {'value': {'a': NULL, 'b': 1}});
+----
+Constraint Error: NOT NULL constraint failed: delta_table.nested_struct.value.a
+
+# finally, a successful insert!
+statement ok
+INSERT INTO delta_table VALUES (1, {'value': 1}, {'value': {'a': 1, 'b': 1}});
+
+# Only 1 went through
+query I
+select count(*)  FROM delta_table;
+----
+11
+
+statement ok
+DETACH delta_table;
+
+statement ok
+ATTACH '__TEST_DIR__/non_nullable/null_constraints_lists/delta_lake' AS delta_table (TYPE delta);
+
+query I
+select count(*)  FROM delta_table;
+----
+10
+
+# Any insert is disallowed whenever non-nullable fields are present
+statement error
+INSERT INTO delta_table VALUES (1, [{'value':1}]);
+----
+Not implemented Error: Inserting into a table with null constraints in arrays is not supported
+
+query I
+select count(*)  FROM delta_table;
+----
+10


### PR DESCRIPTION
Fixes an issue where duckdb would write to delta tables with not null constraints. 

This is now fixed for primitive types and struct types, however list types with not null constraints in them are currently not supported. When trying to insert data into them we will throw a NotImplementedException.

### Follow ups
- Nested Not Null constraints are now implemented in custom way for delta. We may want to upstream this to DuckDB
- Better testing infrastructure to allow writing multi-engine tests to catch and test similar issues
- Support null constraints in list types
