### PR TITLE
Added absolute path support for delta log path.

### DIFF
--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -417,7 +417,7 @@ void ScanDataCallBack::VisitCallbackInternal(ffi::NullableCvoid engine_context, 
 
 	auto path_string = snapshot.GetPath();
 	auto sub_path = KernelUtils::FromDeltaString(path);
-	if (StringUtil::StartsWith(sub_path, "/")) {
+	if (StringUtil::StartsWith(sub_path, "/") && sub_path.find('/', 1) != std::string::npos) {
 		path_string = sub_path;
 	} else {
 		StringUtil::RTrim(path_string, "/");


### PR DESCRIPTION
Closes #247.

This adds support for handling absolute paths in delta log like
```
  {
    "add": {
      "path": "/mnt/datasets/mytable/part0.parquet",
      "size": 2048,
      "modificationTime": 1630425600000,
      "dataChange": true,
      "stats": "{\"numRecords\":100,\"minValues\":{\"id\":1},\"maxValues\":{\"id\":100},\"nullCount\":{\"id\":0}}"
    }
  }
``` 
which produces IO error due to appending the base path from `snapshot.path` with delta log `path`.
```
D SELECT COUNT(*) FROM delta_scan("file:///mnt/datasets/mytable");
IO Error:
Cannot open file "/mnt/datasets/mytable//mnt/datasets/mytable/part0.parquet": No such file or directory
```
With fix:
```
D SELECT COUNT(*) FROM delta_scan("file:///mnt/datasets/mytable");
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│     4875     │
└──────────────┘
```