### PR TITLE
Add tests for arrow being freed properly by kernel

### DIFF
--- a/test/sql/generated/writing/append/test_arrow_release.test
+++ b/test/sql/generated/writing/append/test_arrow_release.test
@@ -1,0 +1,52 @@
+# name: test/sql/generated/writing/append/test_arrow_release.test
+# description: Test to prove that arrow data is released properly by kernel
+# group: [generated]
+
+require parquet
+
+require delta
+
+require-env GENERATED_DATA_AVAILABLE
+
+# Use logging to log creates and releases of arrow data
+statement ok
+CALL enable_logging(level='trace')
+
+statement ok
+CALL copy_dir('data/generated/simple_table', '__TEST_DIR__/late_materialization/simple_table');
+
+statement ok
+ATTACH '__TEST_DIR__/late_materialization/simple_table/delta_lake' AS simple_table (TYPE delta);
+
+loop i 0 10
+
+statement ok
+INSERT INTO simple_table VALUES (5);
+
+endloop
+
+query I
+SELECT count() >= 10 FROM duckdb_logs where message='Delta ToArrow debug: created CommitInfo'
+----
+true
+
+query I
+SELECT count() >= 10 FROM duckdb_logs where message='Delta ToArrow debug: created WriteMetaData'
+----
+true
+
+query I nosort commit_info_count
+SELECT count() FROM duckdb_logs where message='Delta ToArrow debug: created CommitInfo'
+---
+
+query I nosort commit_info_count
+SELECT count() FROM duckdb_logs where message='Delta ToArrow debug: released CommitInfo'
+----
+
+query I nosort write_metadata_count
+SELECT count() FROM duckdb_logs where message='Delta ToArrow debug: created WriteMetaData'
+---
+
+query I nosort write_metadata_count
+SELECT count() FROM duckdb_logs where message= 'Delta ToArrow debug: released WriteMetaData'
+----


### PR DESCRIPTION
This PR uses the logger combined with a simple write test to confirm that arrow data passed to kernel is actually freed by kernel