### PR TITLE
fix url style not work when setting vhost

### DIFF
--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -237,7 +237,12 @@ static ffi::EngineBuilder *CreateBuilder(ClientContext &context, const string &p
 			ffi::set_builder_option(builder, KernelUtils::ToDeltaString("aws_endpoint"),
 			                        KernelUtils::ToDeltaString("https://storage.googleapis.com"));
 		}
-
+		if (secret_type == "s3"){
+			if (!url_style.empty() && url_style == "vhost"){
+				ffi::set_builder_option(builder, KernelUtils::ToDeltaString("aws_virtual_hosted_style_request"),
+				                        KernelUtils::ToDeltaString("true"));
+			}
+		}
 		ffi::set_builder_option(builder, KernelUtils::ToDeltaString("aws_region"), KernelUtils::ToDeltaString(region));
 
 	} else if (secret_type == "azure") {


### PR DESCRIPTION
solve issue: https://github.com/duckdb/duckdb-delta/issues/252

before fix

```
CREATE OR REPLACE SECRET alicloud_secret (
              TYPE S3,
              URL_STYLE 'vhost',
              KEY_ID 'xxx',
              SECRET 'xxxx',
              REGION 'ap-southeast-1',
              ENDPOINT 'buckket.oss-ap-southeast-1.aliyuncs.com'

SELECT MAX(cost_time_stamp) as max_timestamp
          FROM delta_scan('s3://bucket/a/s')
  ;
IO Error:
DeltaKernel ObjectStoreError (8): Error interacting with object store: Generic S3 error: Error performing list request: Error performing GET https://bucket.oss-ap-southeast-1.aliyuncs.com/bucket?list-type=2&prefix=a%2Fs%2F_delta_log%2F&start-after=a%2Fs%2F%2F_delta_log%2F00000000000000000000 in 122.593542ms - Server returned non-2xx status code: 404 Not Found: <?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>NoSuchKey</Code>
  <Message>The specified key does not exist.</Message>
  <RequestId>68E6853E41CA9434377C5A4D</RequestId>
  <HostId>bucket</HostId>
  <Key>bucket</Key>
  <EC>0026-00000001</EC>
  <RecommendDoc>https://api.alibabacloud.com/troubleshoot?q=0026-00000001</RecommendDoc>
</Error>

```

after query success

```
SELECT MAX(cost_time_stamp) as max_timestamp
          FROM delta_scan('s3://bucket/a/s')
───────────────┐
│ max_timestamp │
│     int64     │
├───────────────┤
│     NULL      │
└───────────────┘
```