### PR TITLE
fix write path asserts in commit

### DIFF
--- a/src/include/path_utils.hpp
+++ b/src/include/path_utils.hpp
@@ -18,6 +18,9 @@
 
 namespace duckdb {
 
+// relative: a/b -> $PWD/a/b, absolute: return `path`
+Path PathToAbsolute(const Path &path);
+
 // file:/{1,3}... -> /..., throws if non-local
 Path PathToLocal(const Path &path);
 

--- a/src/path_utils.cpp
+++ b/src/path_utils.cpp
@@ -1,13 +1,20 @@
 #include "path_utils.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/file_system.hpp"
 
 //
 // TODO: (@benfleis) after ToLocal/ToFileLocal/GetCommonLineage land in duckdb core, delete this file.
 //
 
 namespace duckdb {
+
+Path PathToAbsolute(const Path &path) {
+	if (path.IsAbsolute()) {
+		return path;
+	}
+	return Path::FromString(FileSystem::GetWorkingDirectory()).Join(path);
+}
 
 Path PathToLocal(const Path &path) {
 	if (!path.IsLocal()) {

--- a/src/storage/delta_transaction.cpp
+++ b/src/storage/delta_transaction.cpp
@@ -415,11 +415,9 @@ void DeltaTransaction::Commit(ClientContext &context) {
 				    optional_ptr<string>(static_cast<string *>(ffi::get_write_path(write_context, allocate_string)));
 
 				if (write_path_str && delta_path.IsLocal()) {
-					auto write_path = PathToLocal(Path::FromString(*write_path_str));
-					D_ASSERT(write_path.IsAbsolute());
-					auto cwd_path = PathToLocal(Path::FromString(FileSystem::GetWorkingDirectory()));
+					auto write_path = PathToLocal(PathToAbsolute(Path::FromString(*write_path_str)));
 					for (const auto &append : outstanding_appends) {
-						auto append_path = cwd_path.Join(append.file_name); // yay! RHS/LHS common prefix joins
+						auto append_path = PathToLocal(PathToAbsolute(Path::FromString(append.file_name)));
 						if (PathGetCommonLineage(append_path, write_path) < 0) {
 							throw InternalException("Incorrect write path detected: %s does not start with %s",
 							                        append.file_name, *write_path_str);


### PR DESCRIPTION
restructure the path checks during commit to cover a new case of unity emitting write paths which was correct, but fired an assertion during tests.