### PR TITLE
fix null stat handling, exception string formatting and remove write path assert

### DIFF
--- a/src/storage/delta_transaction.cpp
+++ b/src/storage/delta_transaction.cpp
@@ -407,25 +407,6 @@ void DeltaTransaction::Commit(ClientContext &context) {
 		if (!outstanding_appends.empty()) {
 			auto write_context = ffi::get_write_context(kernel_transaction.get());
 
-			{
-				// in local files, path can be relative, but kernel emits absolute path; confirm this with in situ
-				// canonicalization and move on; this block is like a big D_ASSERT
-				auto delta_path = Path::FromString(table_entry->snapshot->GetPath());
-				auto write_path_str =
-				    optional_ptr<string>(static_cast<string *>(ffi::get_write_path(write_context, allocate_string)));
-
-				if (write_path_str && delta_path.IsLocal()) {
-					auto write_path = PathToLocal(PathToAbsolute(Path::FromString(*write_path_str)));
-					for (const auto &append : outstanding_appends) {
-						auto append_path = PathToLocal(PathToAbsolute(Path::FromString(append.file_name)));
-						if (PathGetCommonLineage(append_path, write_path) < 0) {
-							throw InternalException("Incorrect write path detected: %s does not start with %s",
-							                        append.file_name, *write_path_str);
-						}
-					}
-				}
-			}
-
 			// Create metadata from the current outstanding appends
 			WriteMetaData write_metadata(*table_entry->snapshot, outstanding_appends);
 			// Convert write metadata to ArrowFFI

--- a/src/storage/delta_transaction.cpp
+++ b/src/storage/delta_transaction.cpp
@@ -152,11 +152,17 @@ static Value CreateValueLogicalTypeFromStatNode(const unordered_map<string, Stat
 	for (const auto &node : tree) {
 		if (node.second.children.size() == 0) {
 			if (field == "min") {
-				children.push_back({node.first, Value(node.second.stats.min).DefaultCastAs(node.second.type)});
+				children.push_back({node.first, node.second.stats.has_min
+				                                    ? Value(node.second.stats.min).DefaultCastAs(node.second.type)
+				                                    : Value(node.second.type)});
 			} else if (field == "max") {
-				children.push_back({node.first, Value(node.second.stats.max).DefaultCastAs(node.second.type)});
+				children.push_back({node.first, node.second.stats.has_max
+				                                    ? Value(node.second.stats.max).DefaultCastAs(node.second.type)
+				                                    : Value(node.second.type)});
 			} else if (field == "null_count") {
-				children.push_back({node.first, Value::BIGINT(node.second.stats.null_count)});
+				children.push_back({node.first, node.second.stats.has_null_count
+				                                    ? Value::BIGINT(node.second.stats.null_count)
+				                                    : Value(LogicalType::BIGINT)});
 			} else {
 				throw InternalException("Invalid field: %s", field.c_str());
 			}

--- a/src/storage/delta_transaction_manager.cpp
+++ b/src/storage/delta_transaction_manager.cpp
@@ -22,10 +22,10 @@ static ErrorData HandleConflict(DeltaTransaction &transaction, ErrorData &origin
 		transaction.CleanUpFiles();
 	} catch (std::exception &ex) {
 		ErrorData new_error(ex);
-		string new_message =
-		    StringUtil::Format("Multiple exceptions happened. Firstly, the DeltaTransaction failed to commit with "
-		                       "'%s'. Secondly, DuckDB failed to clean up the files produced by this transaction: '%s'",
-		                       original_error.Message());
+		string new_message = StringUtil::Format(
+		    "Multiple exceptions happened. Firstly, the DeltaTransaction failed to commit with "
+		    "'%s'. Secondly, DuckDB failed to clean up the files produced by this transaction, with: '%s'",
+		    original_error.Message(), new_error.Message());
 		return ErrorData(original_error.Type(), new_message);
 	}
 	return original_error;

--- a/test/sql/issues/null_stats_conversion__issue_297.test
+++ b/test/sql/issues/null_stats_conversion__issue_297.test
@@ -1,0 +1,53 @@
+# name: test/sql/issues/null_stats_conversion__issue_297.test
+# description: inserting rows with all-NULL DOUBLE columns must not crash during commit
+# group: [issues]
+
+#              (parquet omits min/max for all-NULL columns; has_min/has_max must be checked)
+
+require parquet
+
+require delta
+
+require json
+
+statement ok
+from copy_dir('data/inlined/simple_table/delta_lake', '__TEST_DIR__/null_stats');
+
+statement ok
+ATTACH '__TEST_DIR__/null_stats' AS null_stats (TYPE delta, READ_ONLY false);
+
+# Insert non-null (=42), then NULL to get both real min/max and null stats in 2 transactions.
+statement ok
+INSERT INTO null_stats VALUES (42);
+
+statement ok
+INSERT INTO null_stats VALUES (NULL);
+
+# verify inserts
+query I rowsort
+SELECT i FROM null_stats WHERE i IS NULL OR i = 42 ORDER BY i;
+----
+42
+NULL
+
+# v1 (non-NULL insert): min/max present, nullCount=0
+query III
+SELECT
+    json_extract_string(add.stats, '$.minValues.i'),
+    json_extract_string(add.stats, '$.maxValues.i'),
+    json_extract_string(add.stats, '$.nullCount.i')
+FROM read_json('__TEST_DIR__/null_stats/_delta_log/00000000000000000001.json')
+WHERE add IS NOT NULL
+----
+42	42	0
+
+# v2 (all-NULL insert): min/max absent, nullCount=1
+query III
+SELECT
+    json_extract_string(add.stats, '$.minValues.i'),
+    json_extract_string(add.stats, '$.maxValues.i'),
+    json_extract_string(add.stats, '$.nullCount.i')
+FROM read_json('__TEST_DIR__/null_stats/_delta_log/00000000000000000002.json')
+WHERE add IS NOT NULL
+----
+NULL	NULL	1

--- a/test/sql/issues/null_stats_conversion__issue_297.test
+++ b/test/sql/issues/null_stats_conversion__issue_297.test
@@ -10,6 +10,8 @@ require delta
 
 require json
 
+require notwindows # paths to JSON fail, skip windows
+
 statement ok
 from copy_dir('data/inlined/simple_table/delta_lake', '__TEST_DIR__/null_stats');
 


### PR DESCRIPTION
Addresses issues found in #295 and its repro testing

- fix handling of null/missing stats (min, max, null_count)
- fix exception condition string format
- remove write path assertion which cannot currently handle canonical forms returned by delta (e.g. on mac /private/tmp vs /tmp)

Both fixes difficult to repro in tests, but manually confirmed with failure injections.