### PR TITLE
Use modern, parallel test runner

### DIFF
--- a/.github/workflows/CloudTesting.yml
+++ b/.github/workflows/CloudTesting.yml
@@ -95,4 +95,4 @@ jobs:
           AZURE_STORAGE_ACCOUNT: ${{secrets.AZURE_STORAGE_ACCOUNT}}
           DUCKDB_AZURE_PUBLIC_CONTAINER_AVAILABLE: 1
         run: |
-          python3 duckdb/scripts/run_tests_one_by_one.py ./build/release/test/unittest `pwd`/test/sql/cloud/*
+          python3 duckdb/scripts/ci/run_tests.py ./build/release/test/unittest "$PWD/test/sql/cloud/*"


### PR DESCRIPTION
### Context

I want to remove `scripts/run_tests_one_by_one.py` from duckdb, and this CI pipeline was the only usage left of that script in the duckdb org.

### Modern test runner

Use duckdb's test runner in this CI pipeline. 

The test runner provides:
- parallelize tests to ~80% of CPUs.
- test batches to reduce process startup overhead (different from the older `run_tests_one_by_one.py`)
- retry failing test batches in CI (retries a single batch at most twice; in total, 4 batches are retried).