### PR TITLE
Add support for version parameter for `delta_scan` 

### DIFF
--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -1076,6 +1076,14 @@ idx_t DeltaMultiFileList::GetVersion() {
 	return version;
 }
 
+void DeltaMultiFileList::PinVersion(idx_t v) {
+	unique_lock<mutex> lck(lock);
+	if (initialized_snapshot) {
+		throw InternalException("DeltaMultiFileList::PinVersion called after the snapshot was initialized");
+	}
+	version = v;
+}
+
 DeltaFileMetaData &DeltaMultiFileList::GetMetaData(idx_t index) const {
 	unique_lock<mutex> lck(lock);
 	if (index >= metadata.size()) {

--- a/src/functions/delta_scan/delta_multi_file_reader.cpp
+++ b/src/functions/delta_scan/delta_multi_file_reader.cpp
@@ -112,6 +112,15 @@ bool DeltaMultiFileReader::Bind(MultiFileOptions &options, MultiFileList &files,
 		delta_snapshot.delta_log_path = make_uniq<DeltaLogPathArray>(log_tail_setting->second);
 	}
 
+	// MultiFileBind constructs the file list before parsing named parameters, so a `version => N`
+	// captured by ParseOption (and stashed on the reader as `requested_version`) cannot be passed
+	// to DeltaMultiFileList's constructor. Transfer it here, before delta_snapshot.Bind() triggers
+	// snapshot initialization. If a snapshot was injected via function_info (catalog-driven path),
+	// `snapshot` is non-null and PinVersion would have nothing to do, so we skip it.
+	if (!snapshot && requested_version != DConstants::INVALID_INDEX) {
+		delta_snapshot.PinVersion(requested_version);
+	}
+
 	delta_snapshot.Bind(return_types, names);
 
 	return true;
@@ -238,9 +247,7 @@ shared_ptr<MultiFileList> DeltaMultiFileReader::CreateFileList(ClientContext &co
 	if (snapshot) {
 		// TODO: assert that we are querying the same path as this injected snapshot
 		// This takes the kernel snapshot from the delta snapshot and ensures we use that snapshot for reading
-		if (snapshot) {
-			return snapshot;
-		}
+		return snapshot;
 	}
 
 	return make_shared_ptr<DeltaMultiFileList>(context, paths[0], DConstants::INVALID_INDEX);
@@ -302,6 +309,11 @@ bool DeltaMultiFileReader::ParseOption(const string &key, const Value &val, Mult
 	// We need to capture this one to know whether to emit
 	if (loption == "pushdown_filters") {
 		options.custom_options["pushdown_filters"] = val;
+		return true;
+	}
+
+	if (loption == "version") {
+		requested_version = val.DefaultCastAs(LogicalType::UBIGINT).GetValue<idx_t>();
 		return true;
 	}
 

--- a/src/functions/delta_scan/delta_scan.cpp
+++ b/src/functions/delta_scan/delta_scan.cpp
@@ -112,6 +112,7 @@ TableFunctionSet DeltaFunctions::GetDeltaScanFunction(ExtensionLoader &loader) {
 		function.named_parameters["pushdown_partition_info"] = LogicalType::BOOLEAN;
 		function.named_parameters["pushdown_filters"] = LogicalType::VARCHAR;
 		function.named_parameters["log_tail"] = KernelUtils::GetLogPathType();
+		function.named_parameters["version"] = LogicalType::UBIGINT;
 
 		function.name = "delta_scan";
 	}

--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
@@ -83,6 +83,9 @@ public:
 	unique_ptr<NodeStatistics> GetCardinality(ClientContext &context) const override;
 	DeltaFileMetaData &GetMetaData(idx_t index) const;
 	idx_t GetVersion();
+	//! Pin a specific version on a not-yet-initialized snapshot. Must be called before any operation
+	//! that would trigger InitializeSnapshot (e.g. Bind, GetAllFiles).
+	void PinVersion(idx_t v);
 	vector<string> GetPartitionColumns();
 
 	vector<DeltaMultiFileColumnDefinition> &GetLazyLoadedGlobalColumns() const;

--- a/src/include/functions/delta_scan/delta_multi_file_reader.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_reader.hpp
@@ -68,6 +68,9 @@ struct DeltaMultiFileReader : public MultiFileReader {
 	// A snapshot can be injected into the multifilereader, this ensures the GetMultiFileList can return this snapshot
 	// (note that the path should match the one passed to CreateFileList)
 	shared_ptr<DeltaMultiFileList> snapshot;
+	// Version requested via the `version` named parameter, captured in ParseOption. Used as a
+	// fallback by CreateFileList when no pre-built snapshot was injected via function_info.
+	idx_t requested_version = DConstants::INVALID_INDEX;
 };
 
 } // namespace duckdb

--- a/src/storage/delta_table_entry.cpp
+++ b/src/storage/delta_table_entry.cpp
@@ -76,6 +76,9 @@ TableFunction DeltaTableEntry::GetScanFunctionInternal(ClientContext &context, u
 	// Propagate settings
 	param_map.insert({"pushdown_partition_info", delta_catalog.pushdown_partition_info});
 	param_map.insert({"pushdown_filters", DeltaEnumUtils::ToString(delta_catalog.filter_pushdown_mode)});
+	if (delta_catalog.use_specific_version != DConstants::INVALID_INDEX) {
+		param_map.insert({"version", Value::UBIGINT(delta_catalog.use_specific_version)});
+	}
 
 	TableFunctionBindInput bind_input(inputs, param_map, return_types, names, nullptr, nullptr, delta_scan_function,
 	                                  empty_ref);

--- a/src/storage/delta_table_entry.cpp
+++ b/src/storage/delta_table_entry.cpp
@@ -76,8 +76,10 @@ TableFunction DeltaTableEntry::GetScanFunctionInternal(ClientContext &context, u
 	// Propagate settings
 	param_map.insert({"pushdown_partition_info", delta_catalog.pushdown_partition_info});
 	param_map.insert({"pushdown_filters", DeltaEnumUtils::ToString(delta_catalog.filter_pushdown_mode)});
-	if (delta_catalog.use_specific_version != DConstants::INVALID_INDEX) {
-		param_map.insert({"version", Value::UBIGINT(delta_catalog.use_specific_version)});
+	idx_t param_version =
+	    version != DConstants::INVALID_INDEX ? version : delta_catalog.use_specific_version;
+	if (param_version != DConstants::INVALID_INDEX) {
+		param_map.insert({"version", Value::UBIGINT(param_version)});
 	}
 
 	TableFunctionBindInput bind_input(inputs, param_map, return_types, names, nullptr, nullptr, delta_scan_function,

--- a/src/storage/delta_table_entry.cpp
+++ b/src/storage/delta_table_entry.cpp
@@ -76,8 +76,7 @@ TableFunction DeltaTableEntry::GetScanFunctionInternal(ClientContext &context, u
 	// Propagate settings
 	param_map.insert({"pushdown_partition_info", delta_catalog.pushdown_partition_info});
 	param_map.insert({"pushdown_filters", DeltaEnumUtils::ToString(delta_catalog.filter_pushdown_mode)});
-	idx_t param_version =
-	    version != DConstants::INVALID_INDEX ? version : delta_catalog.use_specific_version;
+	idx_t param_version = version != DConstants::INVALID_INDEX ? version : delta_catalog.use_specific_version;
 	if (param_version != DConstants::INVALID_INDEX) {
 		param_map.insert({"version", Value::UBIGINT(param_version)});
 	}

--- a/test/sql/main/writing/delta_scan_version.test
+++ b/test/sql/main/writing/delta_scan_version.test
@@ -36,26 +36,7 @@ SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/del
 ----
 11
 
-query I
-SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 2);
-----
-12
-
-query I
-SELECT sum(i) FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 0);
-----
-45
-
-query I
-SELECT sum(i) FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 1);
-----
-55
-
-query I
-SELECT sum(i) FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 2);
-----
-66
-
+# Verify the right rows (not just the right count) at each version.
 query I rowsort
 SELECT i FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 1) WHERE i >= 10;
 ----
@@ -73,19 +54,7 @@ SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/del
 ----
 12
 
-# Parity with ATTACH (TYPE delta, VERSION N).
-statement ok
-ATTACH '__TEST_DIR__/main/writing/delta_scan_version/delta_lake' AS t0 (TYPE delta, VERSION 0);
-
-query I
-SELECT count() FROM t0
-EXCEPT
-SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 0);
-----
-
-statement ok
-DETACH t0;
-
+# Row-set parity between catalog ATTACH (VERSION N) and delta_scan(version => N).
 statement ok
 ATTACH '__TEST_DIR__/main/writing/delta_scan_version/delta_lake' AS t1 (TYPE delta, VERSION 1);
 
@@ -104,24 +73,15 @@ SELECT i FROM t1;
 statement ok
 DETACH t1;
 
-# Composition with pushdown_filters.
+# Composition with pushdown_filters: version => 1 (i in 0..10) with i >= 5 -> 6 rows.
 query I
 SELECT count() FROM delta_scan(
     '__TEST_DIR__/main/writing/delta_scan_version/delta_lake',
-    version => 2,
+    version => 1,
     pushdown_filters => 'all'
 ) WHERE i >= 5;
 ----
-7
-
-query I
-SELECT count() FROM delta_scan(
-    '__TEST_DIR__/main/writing/delta_scan_version/delta_lake',
-    version => 0,
-    pushdown_filters => 'all'
-) WHERE i >= 5;
-----
-5
+6
 
 # Out-of-range version is rejected.
 statement error

--- a/test/sql/main/writing/delta_scan_version.test
+++ b/test/sql/main/writing/delta_scan_version.test
@@ -1,0 +1,161 @@
+# name: test/sql/main/writing/delta_scan_version.test
+# description: Test that delta_scan('path', version => N) pins to the requested snapshot version
+#              when invoked directly as a table function (no DeltaCatalog injecting a snapshot).
+# group: [writing]
+
+require parquet
+
+require delta
+
+require notwindows
+
+# -----------------------------------------------------------------------------
+# setup: build a delta lake with versions 0/1/2 by INSERTing into a copy of
+# simple_table (v0 contains values 0..9). We then DETACH so that subsequent
+# reads must rebuild a snapshot from scratch.
+#
+
+statement ok
+FROM copy_dir('data/inlined/simple_table', '__TEST_DIR__/main/writing/delta_scan_version');
+
+statement ok
+ATTACH '__TEST_DIR__/main/writing/delta_scan_version/delta_lake' AS t (TYPE delta);
+
+statement ok
+INSERT INTO t VALUES (10);
+
+statement ok
+INSERT INTO t VALUES (11);
+
+statement ok
+DETACH t;
+
+# -----------------------------------------------------------------------------
+# Variant 1: direct delta_scan call with `version => N` named parameter.
+#
+
+query I
+SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 0);
+----
+10
+
+query I
+SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 1);
+----
+11
+
+query I
+SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 2);
+----
+12
+
+# Sum sanity-check at each version (v0=0..9=45, v1 adds 10 -> 55, v2 adds 11 -> 66)
+query I
+SELECT sum(i) FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 0);
+----
+45
+
+query I
+SELECT sum(i) FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 1);
+----
+55
+
+query I
+SELECT sum(i) FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 2);
+----
+66
+
+# Values that only exist at >= v1 / v2
+query I rowsort
+SELECT i FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 1) WHERE i >= 10;
+----
+10
+
+query I rowsort
+SELECT i FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 2) WHERE i >= 10;
+----
+10
+11
+
+# -----------------------------------------------------------------------------
+# Variant 2: no version => HEAD (= v2 here).
+#
+
+query I
+SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake');
+----
+12
+
+# -----------------------------------------------------------------------------
+# Variant 3: parity with the catalog-level ATTACH (TYPE delta, VERSION N).
+#
+
+statement ok
+ATTACH '__TEST_DIR__/main/writing/delta_scan_version/delta_lake' AS t0 (TYPE delta, VERSION 0);
+
+query I
+SELECT count() FROM t0;
+----
+10
+
+query I
+SELECT count() FROM t0
+EXCEPT
+SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 0);
+----
+
+statement ok
+DETACH t0;
+
+statement ok
+ATTACH '__TEST_DIR__/main/writing/delta_scan_version/delta_lake' AS t1 (TYPE delta, VERSION 1);
+
+query I
+SELECT count() FROM t1;
+----
+11
+
+query I rowsort
+SELECT i FROM t1
+EXCEPT
+SELECT i FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 1);
+----
+
+query I rowsort
+SELECT i FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 1)
+EXCEPT
+SELECT i FROM t1;
+----
+
+statement ok
+DETACH t1;
+
+# -----------------------------------------------------------------------------
+# Variant 4: version composes with other named parameters (filter pushdown).
+#
+
+query I
+SELECT count() FROM delta_scan(
+    '__TEST_DIR__/main/writing/delta_scan_version/delta_lake',
+    version => 2,
+    pushdown_filters => 'all'
+) WHERE i >= 5;
+----
+7
+
+query I
+SELECT count() FROM delta_scan(
+    '__TEST_DIR__/main/writing/delta_scan_version/delta_lake',
+    version => 0,
+    pushdown_filters => 'all'
+) WHERE i >= 5;
+----
+5
+
+# -----------------------------------------------------------------------------
+# Variant 5: out-of-range version is rejected by the kernel.
+#
+
+statement error
+SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 999);
+----

--- a/test/sql/main/writing/delta_scan_version.test
+++ b/test/sql/main/writing/delta_scan_version.test
@@ -1,6 +1,5 @@
 # name: test/sql/main/writing/delta_scan_version.test
-# description: Test that delta_scan('path', version => N) pins to the requested snapshot version
-#              when invoked directly as a table function (no DeltaCatalog injecting a snapshot).
+# description: delta_scan('path', version => N) pins the snapshot to N.
 # group: [writing]
 
 require parquet
@@ -9,12 +8,8 @@ require delta
 
 require notwindows
 
-# -----------------------------------------------------------------------------
-# setup: build a delta lake with versions 0/1/2 by INSERTing into a copy of
-# simple_table (v0 contains values 0..9). We then DETACH so that subsequent
-# reads must rebuild a snapshot from scratch.
-#
-
+# Build versions 0/1/2 by INSERTing into a copy of simple_table (v0 = 0..9).
+# DETACH so subsequent reads must rebuild a snapshot from scratch.
 statement ok
 FROM copy_dir('data/inlined/simple_table', '__TEST_DIR__/main/writing/delta_scan_version');
 
@@ -30,10 +25,7 @@ INSERT INTO t VALUES (11);
 statement ok
 DETACH t;
 
-# -----------------------------------------------------------------------------
-# Variant 1: direct delta_scan call with `version => N` named parameter.
-#
-
+# Direct delta_scan(version => N).
 query I
 SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 0);
 ----
@@ -49,7 +41,6 @@ SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/del
 ----
 12
 
-# Sum sanity-check at each version (v0=0..9=45, v1 adds 10 -> 55, v2 adds 11 -> 66)
 query I
 SELECT sum(i) FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 0);
 ----
@@ -65,7 +56,6 @@ SELECT sum(i) FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delt
 ----
 66
 
-# Values that only exist at >= v1 / v2
 query I rowsort
 SELECT i FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 1) WHERE i >= 10;
 ----
@@ -77,26 +67,15 @@ SELECT i FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lak
 10
 11
 
-# -----------------------------------------------------------------------------
-# Variant 2: no version => HEAD (= v2 here).
-#
-
+# No version => HEAD (= v2).
 query I
 SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake');
 ----
 12
 
-# -----------------------------------------------------------------------------
-# Variant 3: parity with the catalog-level ATTACH (TYPE delta, VERSION N).
-#
-
+# Parity with ATTACH (TYPE delta, VERSION N).
 statement ok
 ATTACH '__TEST_DIR__/main/writing/delta_scan_version/delta_lake' AS t0 (TYPE delta, VERSION 0);
-
-query I
-SELECT count() FROM t0;
-----
-10
 
 query I
 SELECT count() FROM t0
@@ -109,11 +88,6 @@ DETACH t0;
 
 statement ok
 ATTACH '__TEST_DIR__/main/writing/delta_scan_version/delta_lake' AS t1 (TYPE delta, VERSION 1);
-
-query I
-SELECT count() FROM t1;
-----
-11
 
 query I rowsort
 SELECT i FROM t1
@@ -130,10 +104,7 @@ SELECT i FROM t1;
 statement ok
 DETACH t1;
 
-# -----------------------------------------------------------------------------
-# Variant 4: version composes with other named parameters (filter pushdown).
-#
-
+# Composition with pushdown_filters.
 query I
 SELECT count() FROM delta_scan(
     '__TEST_DIR__/main/writing/delta_scan_version/delta_lake',
@@ -152,10 +123,7 @@ SELECT count() FROM delta_scan(
 ----
 5
 
-# -----------------------------------------------------------------------------
-# Variant 5: out-of-range version is rejected by the kernel.
-#
-
+# Out-of-range version is rejected.
 statement error
 SELECT count() FROM delta_scan('__TEST_DIR__/main/writing/delta_scan_version/delta_lake', version => 999);
 ----


### PR DESCRIPTION
This adds support for the version parameter for delta scans. This is not just convenient for people using the `delta_scan` API, but it also required for MotherDuck, since the snapshot  containing all the version information is not serialized and a client-side attached catalog can therefore also not transfer the version it was querying to the server