### PR TITLE
Reject writes to `ATTACH ... (VERSION N)`

### DIFF
--- a/src/delta_extension.cpp
+++ b/src/delta_extension.cpp
@@ -38,6 +38,7 @@ static unique_ptr<Catalog> DeltaCatalogAttach(optional_ptr<StorageExtensionInfo>
 		if (StringUtil::Lower(option.first) == "version") {
 			res->use_cache = true;
 			res->use_specific_version = UBigIntValue::Get(option.second.DefaultCastAs(LogicalType::UBIGINT));
+			res->access_mode = AccessMode::READ_ONLY;
 		}
 		if (StringUtil::Lower(option.first) == "internal_table_name") {
 			res->internal_table_name = StringValue::Get(option.second);

--- a/test/sql/main/writing/write_to_versioned_attach.test
+++ b/test/sql/main/writing/write_to_versioned_attach.test
@@ -1,0 +1,20 @@
+# name: test/sql/main/writing/write_to_versioned_attach.test
+# group: [writing]
+
+require parquet
+
+require delta
+
+require notwindows
+
+statement ok
+FROM copy_dir('data/inlined/simple_table', '__TEST_DIR__/main/writing/write_to_versioned_attach');
+
+statement ok
+ATTACH '__TEST_DIR__/main/writing/write_to_versioned_attach/delta_lake' AS t (TYPE delta, VERSION 0);
+
+statement error
+INSERT INTO t VALUES (42);
+----
+Can not append to a read only table
+


### PR DESCRIPTION
Writing to a database attached at a specific version is (imo) inherently confusing. Two possible behaviors, both bad:

* The next read sees the write - which contradicts the pinned version.
* The next read returns the old version - which is also not great and will confuse people (me)

This PR sidesteps the problem by disabling writes to catalogs attached at fixed versions. For reference, the insert in my added test currently triggers a NullPtrException.