### PR TITLE
support (UC) passthrough of max_catalog_version for staged commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 EXT_NAME=deltatable
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
-PIP=python3 -m pip
+PYTHON_PIP=python3 -m pip
+PYTHON_BIN=python3
 
 ifeq ($(SANITIZER_MODE), thread)
 	EXT_DEBUG_FLAGS:=-DENABLE_THREAD_SANITIZER=1
@@ -49,8 +50,8 @@ include benchmark/benchmark.Makefile
 #   export JAVA_HOME=/opt/homebrew/Cellar/openjdk@11/11.0.27/libexec/openjdk.jdk/Contents/Home
 generate-data:
 	# NOTE: @benfleis - for now pin versions that work, since unversioned/HEAD caused a big JVM stack trace that I couldn't trivially track down;
-	${PIP} install delta-spark==4.0.0 deltalake==1.2.1 duckdb==1.4.4 pandas==2.3.3 pyarrow==22.0.0 pyspark==4.0.1 typing-extensions==4.15.0
-	python3 scripts/data_generator/generate_test_data.py
+	${PYTHON_PIP} install delta-spark==4.0.0 deltalake==1.2.1 duckdb==1.4.4 pandas==2.3.3 pyarrow==22.0.0 pyspark==4.0.1 typing-extensions==4.15.0
+	${PYTHON_BIN} scripts/data_generator/generate_test_data.py
 	# avoid footguns -- make outputs read only
 	find data/generated -mindepth 1 -print0 | xargs -0 -n 1000 chmod a-w
 

--- a/src/delta_extension.cpp
+++ b/src/delta_extension.cpp
@@ -54,6 +54,9 @@ static unique_ptr<Catalog> DeltaCatalogAttach(optional_ptr<StorageExtensionInfo>
 		if (StringUtil::Lower(option.first) == "log_tail") {
 			res->catalog_log_tail = option.second;
 		}
+		if (StringUtil::Lower(option.first) == "max_catalog_version") {
+			res->max_catalog_version = option.second.GetValue<int64_t>();
+		}
 		if (StringUtil::Lower(option.first) == "unity_table_id") {
 			res->unity_table_id = StringValue::Get(option.second);
 		}

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -730,6 +730,9 @@ void DeltaMultiFileList::InitializeSnapshot() const {
 		if (delta_log_path) {
 			TryUnpackKernelResult(ffi::snapshot_builder_set_log_tail(&builder, delta_log_path->GetFFIPtr()));
 		}
+		if (max_catalog_version >= 0) {
+			ffi::snapshot_builder_set_max_catalog_version(&builder, static_cast<uint64_t>(max_catalog_version));
+		}
 		snapshot = make_shared_ptr<SharedKernelSnapshot>(TryUnpackKernelResult(ffi::snapshot_builder_build(builder)));
 
 		auto snapshot_ref = snapshot->GetLockingRef();

--- a/src/include/functions/delta_scan/delta_multi_file_list.hpp
+++ b/src/include/functions/delta_scan/delta_multi_file_list.hpp
@@ -120,6 +120,7 @@ public: // TODO: clean up
 	mutable shared_ptr<SharedKernelSnapshot> snapshot;
 
 	mutable unique_ptr<DeltaLogPathArray> delta_log_path;
+	mutable int64_t max_catalog_version = -1;
 
 protected:
 	// Note: Nearly this entire class is mutable because it represents a lazily expanded list of files that is logically

--- a/src/include/storage/delta_catalog.hpp
+++ b/src/include/storage/delta_catalog.hpp
@@ -46,8 +46,9 @@ public:
 	optional_ptr<TableFunctionCatalogEntry> commit_function;
 	string unity_table_id;
 
-	// Store the log_tail for catalog-managed commits (CCV2)
+	// Store the log_tail and max_catalog_version for CMTs
 	Value catalog_log_tail;
+	int64_t max_catalog_version = -1;
 
 public:
 	string GetInternalTableName() {

--- a/src/storage/delta_schema_entry.cpp
+++ b/src/storage/delta_schema_entry.cpp
@@ -110,9 +110,12 @@ unique_ptr<DeltaTableEntry> DeltaSchemaEntry::CreateTableEntry(ClientContext &co
 	auto &delta_catalog = catalog.Cast<DeltaCatalog>();
 	auto snapshot = make_shared_ptr<DeltaMultiFileList>(context, delta_catalog.GetDBPath(), version, old_snapshot);
 
-	// Set log_tail for catalog-managed commits (CCV2) if available
+	// Set log_tail and max_catalog_version for catalog-managed commits (CCV2) if available
 	if (!delta_catalog.catalog_log_tail.IsNull()) {
 		snapshot->delta_log_path = make_uniq<DeltaLogPathArray>(delta_catalog.catalog_log_tail);
+	}
+	if (delta_catalog.max_catalog_version >= 0) {
+		snapshot->max_catalog_version = delta_catalog.max_catalog_version;
 	}
 
 	// Get the names and types from the delta snapshot


### PR DESCRIPTION
unity catalog fails to pass through max_catalog_version in the presence of ratified commits, causing failure to read or write. These delta changes pass the max version through (when available). Tests found in [dependent unity_catalog commit](https://github.com/duckdb/unity_catalog/pull/85).