### PR TITLE
fix: 320 azure workload identity authentication

### DIFF
--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -24,6 +24,7 @@
 
 #include <regex>
 #include <algorithm>
+#include <cstdlib>
 
 #include "duckdb/planner/constraints/bound_not_null_constraint.hpp"
 
@@ -289,7 +290,22 @@ static ffi::EngineBuilder *CreateBuilder(ClientContext &context, const string &p
 			if (chain.find("cli") != std::string::npos) {
 				set_option(builder, "use_azure_cli", "true");
 			}
-			// Authentication option 1b: non-cli credential chains will just "hope for the best" technically since we
+			// Authentication option 1b: using a workload_identity
+			// Explicitly forward workload identity vars so object_store selects
+			// WorkloadIdentityOAuthProvider instead of falling back to IMDS
+			if (chain.find("workload_identity") != std::string::npos) {
+				// federated_token_file has no DuckDB secret key analog — always read from env
+				const char* fed_token = getenv("AZURE_FEDERATED_TOKEN_FILE");
+				if (fed_token) set_option(builder, "federated_token_file", fed_token);
+				// Prefer secret-sourced values; fall back to env vars if not set in the secret
+				const char* env_client_id = getenv("AZURE_CLIENT_ID");
+				const char* env_tenant_id = getenv("AZURE_TENANT_ID");
+				const string resolved_client_id = !client_id.empty() ? client_id : (env_client_id ? env_client_id : "");
+				const string resolved_tenant_id = !tenant_id.empty() ? tenant_id : (env_tenant_id ? env_tenant_id : "");
+				if (!resolved_client_id.empty()) set_option(builder, "azure_client_id", resolved_client_id);
+				if (!resolved_tenant_id.empty()) set_option(builder, "azure_tenant_id", resolved_tenant_id);
+			}
+			// Authentication option 1c: non-cli credential chains will just "hope for the best" technically since we
 			// are using the default credential chain provider duckDB and delta-kernel-rs should find the same auth
 		} else if (!connection_string.empty() && connection_string != "NULL") {
 			// Authentication option 2: a connection string based on account key

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -294,19 +294,15 @@ static ffi::EngineBuilder *CreateBuilder(ClientContext &context, const string &p
 			// Explicitly forward workload identity vars so object_store selects
 			// WorkloadIdentityOAuthProvider instead of falling back to IMDS
 			if (chain.find("workload_identity") != std::string::npos) {
-				// federated_token_file has no DuckDB secret key analog — always read from env
 				const char *fed_token = getenv("AZURE_FEDERATED_TOKEN_FILE");
-				if (fed_token)
-					set_option(builder, "federated_token_file", fed_token);
-				// Prefer secret-sourced values; fall back to env vars if not set in the secret
 				const char *env_client_id = getenv("AZURE_CLIENT_ID");
 				const char *env_tenant_id = getenv("AZURE_TENANT_ID");
-				const string resolved_client_id = !client_id.empty() ? client_id : (env_client_id ? env_client_id : "");
-				const string resolved_tenant_id = !tenant_id.empty() ? tenant_id : (env_tenant_id ? env_tenant_id : "");
-				if (!resolved_client_id.empty())
-					set_option(builder, "azure_client_id", resolved_client_id);
-				if (!resolved_tenant_id.empty())
-					set_option(builder, "azure_tenant_id", resolved_tenant_id);
+				if (fed_token)
+					set_option(builder, "federated_token_file", fed_token);
+				if (env_client_id)
+					set_option(builder, "azure_client_id", env_client_id);
+				if (env_tenant_id)
+					set_option(builder, "azure_tenant_id", env_tenant_id);
 			}
 			// Authentication option 1c: non-cli credential chains will just "hope for the best" technically since we
 			// are using the default credential chain provider duckDB and delta-kernel-rs should find the same auth

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -295,15 +295,18 @@ static ffi::EngineBuilder *CreateBuilder(ClientContext &context, const string &p
 			// WorkloadIdentityOAuthProvider instead of falling back to IMDS
 			if (chain.find("workload_identity") != std::string::npos) {
 				// federated_token_file has no DuckDB secret key analog — always read from env
-				const char* fed_token = getenv("AZURE_FEDERATED_TOKEN_FILE");
-				if (fed_token) set_option(builder, "federated_token_file", fed_token);
+				const char *fed_token = getenv("AZURE_FEDERATED_TOKEN_FILE");
+				if (fed_token)
+					set_option(builder, "federated_token_file", fed_token);
 				// Prefer secret-sourced values; fall back to env vars if not set in the secret
-				const char* env_client_id = getenv("AZURE_CLIENT_ID");
-				const char* env_tenant_id = getenv("AZURE_TENANT_ID");
+				const char *env_client_id = getenv("AZURE_CLIENT_ID");
+				const char *env_tenant_id = getenv("AZURE_TENANT_ID");
 				const string resolved_client_id = !client_id.empty() ? client_id : (env_client_id ? env_client_id : "");
 				const string resolved_tenant_id = !tenant_id.empty() ? tenant_id : (env_tenant_id ? env_tenant_id : "");
-				if (!resolved_client_id.empty()) set_option(builder, "azure_client_id", resolved_client_id);
-				if (!resolved_tenant_id.empty()) set_option(builder, "azure_tenant_id", resolved_tenant_id);
+				if (!resolved_client_id.empty())
+					set_option(builder, "azure_client_id", resolved_client_id);
+				if (!resolved_tenant_id.empty())
+					set_option(builder, "azure_tenant_id", resolved_tenant_id);
 			}
 			// Authentication option 1c: non-cli credential chains will just "hope for the best" technically since we
 			// are using the default credential chain provider duckDB and delta-kernel-rs should find the same auth

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -290,19 +290,24 @@ static ffi::EngineBuilder *CreateBuilder(ClientContext &context, const string &p
 			if (chain.find("cli") != std::string::npos) {
 				set_option(builder, "use_azure_cli", "true");
 			}
-			// Authentication option 1b: using a workload_identity
+			// Authentication option 1b: using a workload_identity w/ AZURE_FEDERATED_TOKEN_FILE
+			// as required trigger. Fail if common vars client_id or tenant_id missing.
 			// Explicitly forward workload identity vars so object_store selects
 			// WorkloadIdentityOAuthProvider instead of falling back to IMDS
 			if (chain.find("workload_identity") != std::string::npos) {
-				const char *fed_token = getenv("AZURE_FEDERATED_TOKEN_FILE");
-				const char *env_client_id = getenv("AZURE_CLIENT_ID");
-				const char *env_tenant_id = getenv("AZURE_TENANT_ID");
-				if (fed_token)
-					set_option(builder, "federated_token_file", fed_token);
-				if (env_client_id)
-					set_option(builder, "azure_client_id", env_client_id);
-				if (env_tenant_id)
-					set_option(builder, "azure_tenant_id", env_tenant_id);
+				auto env_fed_token = FileSystem::GetEnvVariable("AZURE_FEDERATED_TOKEN_FILE");
+				auto env_client_id = FileSystem::GetEnvVariable("AZURE_CLIENT_ID");
+				auto env_tenant_id = FileSystem::GetEnvVariable("AZURE_TENANT_ID");
+				if (!env_fed_token.empty()) {
+					if (env_client_id.empty() || env_tenant_id.empty()) {
+						throw InvalidInputException("Azure workload_identity requires AZURE_CLIENT_ID and "
+						                            "AZURE_TENANT_ID in environment.");
+					} else {
+						set_option(builder, "federated_token_file", env_fed_token);
+						set_option(builder, "azure_client_id", env_client_id);
+						set_option(builder, "azure_tenant_id", env_tenant_id);
+					}
+				}
 			}
 			// Authentication option 1c: non-cli credential chains will just "hope for the best" technically since we
 			// are using the default credential chain provider duckDB and delta-kernel-rs should find the same auth

--- a/test/sql/cloud/azure/workload_identity_auth.test
+++ b/test/sql/cloud/azure/workload_identity_auth.test
@@ -1,0 +1,41 @@
+# name: test/sql/cloud/azure/workload_identity_auth.test
+# description: test azure delta_scan with workload_identity credential chain (common in AKS)
+# group: [azure]
+
+require azure
+
+require parquet
+
+require delta
+
+require-env AZURE_CLIENT_ID
+
+require-env AZURE_TENANT_ID
+
+require-env AZURE_FEDERATED_TOKEN_FILE
+
+require-env AZURE_STORAGE_ACCOUNT
+
+statement ok
+set allow_persistent_secrets=false
+
+statement ok
+CREATE SECRET az_wi (
+    TYPE AZURE,
+    PROVIDER CREDENTIAL_CHAIN,
+    CHAIN 'workload_identity',
+    ACCOUNT_NAME '${AZURE_STORAGE_ACCOUNT}'
+)
+
+mode output_result
+
+# Run a remote DAT test
+query I rowsort all_primitive_types
+SELECT *
+FROM delta_scan('azure://delta-testing-private/dat/all_primitive_types/delta')
+----
+
+query I rowsort all_primitive_types
+SELECT *
+FROM parquet_scan('azure://delta-testing-private/dat/all_primitive_types/expected/latest/**/*.parquet')
+----

--- a/test/sql/cloud/azure/workload_identity_auth.test
+++ b/test/sql/cloud/azure/workload_identity_auth.test
@@ -2,6 +2,14 @@
 # description: test azure delta_scan with workload_identity credential chain (common in AKS)
 # group: [azure]
 
+# This test is not run in CI, since AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE are never set there.
+# It is useful for local manual verification against a real AKS workload-identity token (See PR #321 discussion).
+# To run locally, export the AZURE_* vars below from an AKS pod, along with copying the token file, and then include
+# AZURE_STORAGE_ACCOUNT and AZURE_DELTA_TEST_PATH to point to a delta table that the workload identity can read and
+# comment out the `mode skip` line temporarily.
+
+mode skip
+
 require azure
 
 require parquet
@@ -16,6 +24,10 @@ require-env AZURE_FEDERATED_TOKEN_FILE
 
 require-env AZURE_STORAGE_ACCOUNT
 
+require-env AZURE_DELTA_TEST_PATH
+
+require-env AZURE_PARQUET_TEST_PATH
+
 statement ok
 set allow_persistent_secrets=false
 
@@ -24,18 +36,20 @@ CREATE SECRET az_wi (
     TYPE AZURE,
     PROVIDER CREDENTIAL_CHAIN,
     CHAIN 'workload_identity',
-    ACCOUNT_NAME '${AZURE_STORAGE_ACCOUNT}'
+    ACCOUNT_NAME '{AZURE_STORAGE_ACCOUNT}'
 )
 
-mode output_result
-
-# Run a remote DAT test
-query I rowsort all_primitive_types
-SELECT *
-FROM delta_scan('azure://delta-testing-private/dat/all_primitive_types/delta')
+# Previously this failed with an IMDS timeout when workload identity
+# env vars were not forwarded to the delta-kernel-rs builder.
+query I
+SELECT count(*) > 0
+FROM delta_scan('{AZURE_DELTA_TEST_PATH}')
 ----
+true
 
-query I rowsort all_primitive_types
-SELECT *
-FROM parquet_scan('azure://delta-testing-private/dat/all_primitive_types/expected/latest/**/*.parquet')
+query I
+SELECT count(*) > 0
+from parquet_scan('{AZURE_PARQUET_TEST_PATH}')
 ----
+true
+

--- a/test/sql/cloud/azure/workload_identity_auth.test
+++ b/test/sql/cloud/azure/workload_identity_auth.test
@@ -2,11 +2,12 @@
 # description: test azure delta_scan with workload_identity credential chain (common in AKS)
 # group: [azure]
 
-# This test is not run in CI, since AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_FEDERATED_TOKEN_FILE are never set there.
+# NOTE: This test is not run in CI, since AZURE_FEDERATED_TOKEN_FILE is not available there.
+#
 # It is useful for local manual verification against a real AKS workload-identity token (See PR #321 discussion).
 # To run locally, export the AZURE_* vars below from an AKS pod, along with copying the token file, and then include
-# AZURE_STORAGE_ACCOUNT and AZURE_DELTA_TEST_PATH to point to a delta table that the workload identity can read and
-# comment out the `mode skip` line temporarily.
+# AZURE_STORAGE_ACCOUNT, AZURE_DELTA_TEST_PATH, AZURE_PARQUET_TEST_PATH to point to a delta table that the workload 
+# identity can read and comment out the `mode skip` line temporarily.
 
 mode skip
 


### PR DESCRIPTION
Add support for Azure Workload Identity.

- workload_identity support in credential chain
- requires `AZURE_{FEDERATED_TOKEN_FILE,CLIENT_ID,TENANT_ID}` to be present in environment (_not_ via duckdb SECRET)
- tested this locally with an AKS cluster with a federated workload identity
- addresses issue #320
- NOTE: Credentialing proceeds via delta-kernel-rs's object_store, _not_ via Azure SDK. This functionality will only work if `CHAIN` names `'workload_identity'`; `default`, `env`, or an unspecified chain will not trigger workload_identity.

Sample syntax:

``` sql
CREATE SECRET az_wi (
    TYPE AZURE,
    PROVIDER CREDENTIAL_CHAIN,
    CHAIN 'workload_identity', -- MUST contain 'workload_identity'
    ACCOUNT_NAME 'my_storage_account'
);
```