### PR TITLE
Delta v0.26.0 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ set(CARGO_PROFILE "$<IF:$<CONFIG:Debug>,dev,release>")
 ExternalProject_Add(
   ${KERNEL_NAME}
   GIT_REPOSITORY "https://github.com/delta-io/delta-kernel-rs"
-  GIT_TAG v0.21.0
+  GIT_TAG v0.25.0
   # Prints the env variables passed to the cargo build to the terminal, useful
   # in debugging because passing them through CMake is an error-prone mess
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${RUST_UNSET_ENV_VARS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ set(CARGO_PROFILE "$<IF:$<CONFIG:Debug>,dev,release>")
 ExternalProject_Add(
   ${KERNEL_NAME}
   GIT_REPOSITORY "https://github.com/delta-io/delta-kernel-rs"
-  GIT_TAG v0.25.0
+  GIT_TAG v0.26.0
   # Prints the env variables passed to the cargo build to the terminal, useful
   # in debugging because passing them through CMake is an error-prone mess
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${RUST_UNSET_ENV_VARS}

--- a/scripts/ffi/generate_delta_kernel_ffi_header
+++ b/scripts/ffi/generate_delta_kernel_ffi_header
@@ -45,11 +45,17 @@ cp "$INPUT_HEADER" "$OUTPUT_HEADER"
 
 # Bring together all the patches into generated header:
 #   /^#pragma once$/    -> append prefix.inc
-#   /^extern/           -> append inline_msvc_compat.inc (generated above)
+#   /^extern "C" \{$/   -> append inline_msvc_compat.inc (generated above)
 #   /^}.*namespace ffi/ -> append suffix.inc
+#
+# NOTE: the injection point must match only the `extern "C" {` block opener, not any
+# top-level `extern` declaration -- kernel headers can also contain plain
+# `extern const uint8_t FOO[N];` statics (e.g. the REST_BUILDER_OPTION_*_KEY constants added
+# in delta-kernel-rs v0.26.0), and a bare `/^extern/` pattern matches those too, injecting
+# (and thus duplicating) the whole struct once per match.
 sed -i.bak \
 	-e "/^#pragma once$/r $SCRIPTS_FFI_DIR/prefix.inc" \
-	-e "/^extern/r $MSVC_COMPAT_INC" \
+	-e "/^extern \"C\" {\$/r $MSVC_COMPAT_INC" \
 	-e "/^}.*namespace.ffi/r $SCRIPTS_FFI_DIR/suffix.inc" \
 	"$OUTPUT_HEADER"
 

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -464,12 +464,12 @@ unique_ptr<ParsedExpression> ExpressionVisitor::MakeStructPatchOp(const string &
 	// encoding.
 	FieldList children_values = std::move(insertions);
 
+	children_values.push_back(
+	    make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, make_uniq<ColumnRefExpression>("keep_input"),
+	                                    make_uniq<ConstantExpression>(Value::BOOLEAN(keep_input))));
 	children_values.push_back(make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
-	                                                           make_uniq<ColumnRefExpression>("keep_input"),
-	                                                           make_uniq<ConstantExpression>(Value::BOOLEAN(keep_input))));
-	children_values.push_back(make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
-	                                                           make_uniq<ColumnRefExpression>("optional"),
-	                                                           make_uniq<ConstantExpression>(Value::BOOLEAN(optional))));
+	                                                          make_uniq<ColumnRefExpression>("optional"),
+	                                                          make_uniq<ConstantExpression>(Value::BOOLEAN(optional))));
 
 	unique_ptr<ParsedExpression> field_name_val;
 	if (field_name) {
@@ -480,15 +480,16 @@ unique_ptr<ParsedExpression> ExpressionVisitor::MakeStructPatchOp(const string &
 	children_values.push_back(make_uniq<ComparisonExpression>(
 	    ExpressionType::COMPARE_EQUAL, make_uniq<ColumnRefExpression>("field_name"), std::move(field_name_val)));
 
-	children_values.push_back(make_uniq<ComparisonExpression>(
-	    ExpressionType::COMPARE_EQUAL, make_uniq<ColumnRefExpression>("kind"), make_uniq<ConstantExpression>(Value(kind))));
+	children_values.push_back(make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
+	                                                          make_uniq<ColumnRefExpression>("kind"),
+	                                                          make_uniq<ConstantExpression>(Value(kind))));
 
 	return make_uniq<FunctionExpression>("delta_transform_op", std::move(children_values));
 }
 
-void ExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t sibling_list_id,
-                                                    uintptr_t input_path_list_id, uintptr_t prepended_field_list_id,
-                                                    uintptr_t field_patch_list_id, uintptr_t appended_field_list_id) {
+void ExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t sibling_list_id, uintptr_t input_path_list_id,
+                                                   uintptr_t prepended_field_list_id, uintptr_t field_patch_list_id,
+                                                   uintptr_t appended_field_list_id) {
 	auto state_cast = static_cast<ExpressionVisitor *>(state);
 
 	auto field_patches = state_cast->TakeFieldList(field_patch_list_id);
@@ -506,7 +507,8 @@ void ExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t siblin
 
 	FieldList children_values;
 	if (!prepended->empty()) {
-		children_values.push_back(state_cast->MakeStructPatchOp("prepend", nullptr, std::move(*prepended), false, false));
+		children_values.push_back(
+		    state_cast->MakeStructPatchOp("prepend", nullptr, std::move(*prepended), false, false));
 	}
 	for (auto &field_patch : *field_patches) {
 		children_values.push_back(std::move(field_patch));

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -72,6 +72,9 @@ ffi::EngineExpressionVisitor ExpressionVisitor::CreateVisitor(ExpressionVisitor 
 	visitor.visit_literal_binary = &VisitBinaryLiteral;
 	visitor.visit_literal_null = &VisitNullLiteral;
 	visitor.visit_literal_array = &VisitArrayLiteral;
+	// visit_array constructs a non-literal ARRAY[...] expression; the child-list-to-list_value()
+	// logic is identical to the literal-array case.
+	visitor.visit_array = &VisitArrayLiteral;
 
 	visitor.visit_and = VisitVariadicExpression<ExpressionType::CONJUNCTION_AND, ConjunctionExpression>();
 	visitor.visit_or = VisitVariadicExpression<ExpressionType::CONJUNCTION_OR, ConjunctionExpression>();
@@ -93,8 +96,8 @@ ffi::EngineExpressionVisitor ExpressionVisitor::CreateVisitor(ExpressionVisitor 
 	visitor.visit_column = VisitColumnExpression;
 	visitor.visit_struct_expr = VisitStructExpression;
 
-	visitor.visit_transform_expr = VisitTransformExpression;
-	visitor.visit_field_transform = VisitFieldTransform;
+	visitor.visit_struct_patch_expr = VisitStructPatchExpression;
+	visitor.visit_field_patch = VisitFieldPatch;
 
 	visitor.visit_literal_struct = VisitStructLiteral;
 
@@ -257,7 +260,10 @@ void ExpressionVisitor::VisitBinaryLiteral(void *state, uintptr_t sibling_list_i
 	auto expression = make_uniq<ConstantExpression>(Value::BLOB(buffer, len));
 	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitNullLiteral(void *state, uintptr_t sibling_list_id) {
+void ExpressionVisitor::VisitNullLiteral(void *state, uintptr_t sibling_list_id, uint8_t type_tag, uint8_t precision,
+                                         uint8_t scale) {
+	// type_tag/precision/scale identify the kernel-side data type of the null; we don't need it
+	// since DuckDB's untyped NULL constant is cast to the correct type by the surrounding context.
 	auto expression = make_uniq<ConstantExpression>(Value());
 	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
@@ -448,66 +454,103 @@ void ExpressionVisitor::VisitStructExpression(void *state, uintptr_t sibling_lis
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitTransformExpression(void *state, uintptr_t sibling_list_id, uintptr_t input_path_list_id,
-                                                 uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+unique_ptr<ParsedExpression> ExpressionVisitor::MakeStructPatchOp(const string &kind, const string *field_name,
+                                                                  FieldList &&insertions, bool keep_input,
+                                                                  bool optional) {
+	// Encode as "delta_transform_op(<insertion values...>, keep_input, optional, field_name, kind)".
+	// `kind` is one of "prepend"/"field"/"append" and disambiguates the unnamed prepend/append
+	// patches (position-only, no field_name/keep_input/optional semantics) from named field
+	// patches. See FindPartitionValues in delta_multi_file_list.cpp for the consumer of this
+	// encoding.
+	FieldList children_values = std::move(insertions);
 
-	auto children_values = state_cast->TakeFieldList(child_list_id);
-	if (!children_values) {
-		return;
-	}
+	children_values.push_back(make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
+	                                                           make_uniq<ColumnRefExpression>("keep_input"),
+	                                                           make_uniq<ConstantExpression>(Value::BOOLEAN(keep_input))));
+	children_values.push_back(make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
+	                                                           make_uniq<ColumnRefExpression>("optional"),
+	                                                           make_uniq<ConstantExpression>(Value::BOOLEAN(optional))));
 
-	if (input_path_list_id) {
-		auto input_path = state_cast->TakeFieldList(input_path_list_id);
-
-		if (input_path->size() != 1) {
-			state_cast->error = ErrorData("Expected exactly one input path for transform expression");
-			return;
-		}
-		children_values->push_back(make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
-		                                                           make_uniq<ColumnRefExpression>("input_path"),
-		                                                           std::move(input_path->front())));
-	}
-
-	unique_ptr<ParsedExpression> expression =
-	    make_uniq<FunctionExpression>("delta_kernel_transform_expression", std::move(*children_values));
-	state_cast->AppendToList(sibling_list_id, std::move(expression));
-}
-
-void ExpressionVisitor::VisitFieldTransform(void *state, uintptr_t sibling_list_id,
-                                            const ffi::KernelStringSlice *field_name, uintptr_t expr_list_id,
-                                            bool is_replace) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
-
-	unique_ptr<FieldList> children_values;
-
-	if (expr_list_id) {
-		children_values = state_cast->TakeFieldList(expr_list_id);
-		if (!children_values) {
-			return;
-		}
-	} else {
-		children_values = make_uniq<FieldList>();
-	}
-
-	// Create is_insert_value
-	children_values->push_back(
-	    make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL, make_uniq<ColumnRefExpression>("is_replace"),
-	                                    make_uniq<ConstantExpression>(Value::BOOLEAN(is_replace))));
-
-	// Create field name expr
 	unique_ptr<ParsedExpression> field_name_val;
 	if (field_name) {
-		string field_name_str = KernelUtils::FromDeltaString(*field_name);
-		field_name_val = make_uniq<ConstantExpression>(Value(field_name_str));
+		field_name_val = make_uniq<ConstantExpression>(Value(*field_name));
 	} else {
 		field_name_val = make_uniq<ConstantExpression>(Value());
 	}
-	children_values->push_back(make_uniq<ComparisonExpression>(
+	children_values.push_back(make_uniq<ComparisonExpression>(
 	    ExpressionType::COMPARE_EQUAL, make_uniq<ColumnRefExpression>("field_name"), std::move(field_name_val)));
 
+	children_values.push_back(make_uniq<ComparisonExpression>(
+	    ExpressionType::COMPARE_EQUAL, make_uniq<ColumnRefExpression>("kind"), make_uniq<ConstantExpression>(Value(kind))));
+
+	return make_uniq<FunctionExpression>("delta_transform_op", std::move(children_values));
+}
+
+void ExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t sibling_list_id,
+                                                    uintptr_t input_path_list_id, uintptr_t prepended_field_list_id,
+                                                    uintptr_t field_patch_list_id, uintptr_t appended_field_list_id) {
+	auto state_cast = static_cast<ExpressionVisitor *>(state);
+
+	auto field_patches = state_cast->TakeFieldList(field_patch_list_id);
+	if (!field_patches) {
+		return;
+	}
+	auto prepended = state_cast->TakeFieldList(prepended_field_list_id);
+	if (!prepended) {
+		return;
+	}
+	auto appended = state_cast->TakeFieldList(appended_field_list_id);
+	if (!appended) {
+		return;
+	}
+
+	FieldList children_values;
+	if (!prepended->empty()) {
+		children_values.push_back(state_cast->MakeStructPatchOp("prepend", nullptr, std::move(*prepended), false, false));
+	}
+	for (auto &field_patch : *field_patches) {
+		children_values.push_back(std::move(field_patch));
+	}
+	if (!appended->empty()) {
+		children_values.push_back(state_cast->MakeStructPatchOp("append", nullptr, std::move(*appended), false, false));
+	}
+
+	// Unlike prepended/field_patch/appended lists, the kernel always allocates a (possibly empty)
+	// input-path list, even when there is no input path: 0 items means "no path", not "no list".
+	auto input_path = state_cast->TakeFieldList(input_path_list_id);
+	if (!input_path) {
+		return;
+	}
+	if (input_path->size() == 1) {
+		children_values.push_back(make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
+		                                                          make_uniq<ColumnRefExpression>("input_path"),
+		                                                          std::move(input_path->front())));
+	} else if (!input_path->empty()) {
+		state_cast->error = ErrorData("Expected zero or one input path for struct patch expression");
+		return;
+	}
+
 	unique_ptr<ParsedExpression> expression =
-	    make_uniq<FunctionExpression>("delta_transform_op", std::move(*children_values));
+	    make_uniq<FunctionExpression>("delta_kernel_transform_expression", std::move(children_values));
+	state_cast->AppendToList(sibling_list_id, std::move(expression));
+}
+
+void ExpressionVisitor::VisitFieldPatch(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice field_name,
+                                        uintptr_t insertion_expr_list_id, bool keep_input, bool optional) {
+	auto state_cast = static_cast<ExpressionVisitor *>(state);
+
+	FieldList insertions;
+	if (insertion_expr_list_id) {
+		auto taken = state_cast->TakeFieldList(insertion_expr_list_id);
+		if (!taken) {
+			return;
+		}
+		insertions = std::move(*taken);
+	}
+
+	string field_name_str = KernelUtils::FromDeltaString(field_name);
+	auto expression =
+	    state_cast->MakeStructPatchOp("field", &field_name_str, std::move(insertions), keep_input, optional);
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
@@ -574,6 +617,7 @@ ffi::EngineSchemaVisitor SchemaVisitor::CreateSchemaVisitor(SchemaVisitor &state
 	visitor.visit_date = VisitSimpleType<LogicalType::DATE>();
 	visitor.visit_timestamp = VisitSimpleType<LogicalType::TIMESTAMP_TZ>();
 	visitor.visit_timestamp_ntz = VisitSimpleType<LogicalType::TIMESTAMP>();
+	visitor.visit_void = VisitSimpleType<LogicalType::SQLNULL>();
 	visitor.visit_variant = (void (*)(void *data, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
 	                                  bool is_nullable, const ffi::CStringMap *metadata)) &
 	                        VisitVariant;

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -30,8 +30,8 @@
 
 namespace duckdb {
 
-void ExpressionVisitor::VisitComparisonExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitComparisonExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
@@ -45,7 +45,7 @@ void ExpressionVisitor::VisitComparisonExpression(void *state, uintptr_t sibling
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-ffi::EngineExpressionVisitor ExpressionVisitor::CreateVisitor(ExpressionVisitor &state) {
+ffi::EngineExpressionVisitor KernelExpressionVisitor::CreateVisitor(KernelExpressionVisitor &state) {
 	ffi::EngineExpressionVisitor visitor;
 
 	visitor.data = &state;
@@ -117,8 +117,8 @@ ffi::EngineExpressionVisitor ExpressionVisitor::CreateVisitor(ExpressionVisitor 
 }
 
 unique_ptr<vector<unique_ptr<ParsedExpression>>>
-ExpressionVisitor::VisitKernelExpression(const ffi::Expression *expression) {
-	ExpressionVisitor state;
+KernelExpressionVisitor::ToParsedExpression(const ffi::Expression *expression) {
+	KernelExpressionVisitor state;
 	auto visitor = CreateVisitor(state);
 
 	uintptr_t result = ffi::visit_expression_ref(expression, &visitor);
@@ -131,8 +131,8 @@ ExpressionVisitor::VisitKernelExpression(const ffi::Expression *expression) {
 }
 
 unique_ptr<vector<unique_ptr<ParsedExpression>>>
-ExpressionVisitor::VisitKernelExpression(const ffi::Handle<ffi::SharedExpression> *expression) {
-	ExpressionVisitor state;
+KernelExpressionVisitor::ToParsedExpression(const ffi::Handle<ffi::SharedExpression> *expression) {
+	KernelExpressionVisitor state;
 	auto visitor = CreateVisitor(state);
 
 	uintptr_t result = ffi::visit_expression(expression, &visitor);
@@ -145,8 +145,8 @@ ExpressionVisitor::VisitKernelExpression(const ffi::Handle<ffi::SharedExpression
 }
 
 unique_ptr<vector<unique_ptr<ParsedExpression>>>
-ExpressionVisitor::VisitKernelPredicate(const ffi::Handle<ffi::SharedPredicate> *predicate) {
-	ExpressionVisitor state;
+KernelExpressionVisitor::ToParsedExpression(const ffi::Handle<ffi::SharedPredicate> *predicate) {
+	KernelExpressionVisitor state;
 	auto visitor = CreateVisitor(state);
 
 	uintptr_t result = ffi::visit_predicate(predicate, &visitor);
@@ -158,8 +158,8 @@ ExpressionVisitor::VisitKernelPredicate(const ffi::Handle<ffi::SharedPredicate> 
 	return state.TakeFieldList(result);
 }
 
-void ExpressionVisitor::VisitAdditionExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitAdditionExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
 		return;
@@ -169,8 +169,8 @@ void ExpressionVisitor::VisitAdditionExpression(void *state, uintptr_t sibling_l
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitSubtractionExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitSubtractionExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
 		return;
@@ -180,8 +180,8 @@ void ExpressionVisitor::VisitSubtractionExpression(void *state, uintptr_t siblin
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitDivideExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitDivideExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
 		return;
@@ -191,13 +191,13 @@ void ExpressionVisitor::VisitDivideExpression(void *state, uintptr_t sibling_lis
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitCoalesceExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitCoalesceExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	state_cast->error = ErrorData(ExceptionType::NOT_IMPLEMENTED, "Coalesce expression is not supported yet");
 }
 
-void ExpressionVisitor::VisitMultiplyExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitMultiplyExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
 		return;
@@ -207,68 +207,68 @@ void ExpressionVisitor::VisitMultiplyExpression(void *state, uintptr_t sibling_l
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitPrimitiveLiteralBool(void *state, uintptr_t sibling_list_id, bool value) {
+void KernelExpressionVisitor::VisitPrimitiveLiteralBool(void *state, uintptr_t sibling_list_id, bool value) {
 	auto expression = make_uniq<ConstantExpression>(Value::BOOLEAN(value));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitPrimitiveLiteralByte(void *state, uintptr_t sibling_list_id, int8_t value) {
+void KernelExpressionVisitor::VisitPrimitiveLiteralByte(void *state, uintptr_t sibling_list_id, int8_t value) {
 	auto expression = make_uniq<ConstantExpression>(Value::TINYINT(value));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitPrimitiveLiteralShort(void *state, uintptr_t sibling_list_id, int16_t value) {
+void KernelExpressionVisitor::VisitPrimitiveLiteralShort(void *state, uintptr_t sibling_list_id, int16_t value) {
 	auto expression = make_uniq<ConstantExpression>(Value::SMALLINT(value));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitPrimitiveLiteralInt(void *state, uintptr_t sibling_list_id, int32_t value) {
+void KernelExpressionVisitor::VisitPrimitiveLiteralInt(void *state, uintptr_t sibling_list_id, int32_t value) {
 	auto expression = make_uniq<ConstantExpression>(Value::INTEGER(value));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitPrimitiveLiteralLong(void *state, uintptr_t sibling_list_id, int64_t value) {
+void KernelExpressionVisitor::VisitPrimitiveLiteralLong(void *state, uintptr_t sibling_list_id, int64_t value) {
 	auto expression = make_uniq<ConstantExpression>(Value::BIGINT(value));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitPrimitiveLiteralFloat(void *state, uintptr_t sibling_list_id, float value) {
+void KernelExpressionVisitor::VisitPrimitiveLiteralFloat(void *state, uintptr_t sibling_list_id, float value) {
 	auto expression = make_uniq<ConstantExpression>(Value::FLOAT(value));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitPrimitiveLiteralDouble(void *state, uintptr_t sibling_list_id, double value) {
+void KernelExpressionVisitor::VisitPrimitiveLiteralDouble(void *state, uintptr_t sibling_list_id, double value) {
 	auto expression = make_uniq<ConstantExpression>(Value::DOUBLE(value));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitTimestampLiteral(void *state, uintptr_t sibling_list_id, int64_t value) {
+void KernelExpressionVisitor::VisitTimestampLiteral(void *state, uintptr_t sibling_list_id, int64_t value) {
 	auto expression = make_uniq<ConstantExpression>(Value::TIMESTAMPTZ(timestamp_tz_t(value)));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitTimestampNtzLiteral(void *state, uintptr_t sibling_list_id, int64_t value) {
+void KernelExpressionVisitor::VisitTimestampNtzLiteral(void *state, uintptr_t sibling_list_id, int64_t value) {
 	auto expression = make_uniq<ConstantExpression>(Value::TIMESTAMP(static_cast<timestamp_t>(value)));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitDateLiteral(void *state, uintptr_t sibling_list_id, int32_t value) {
+void KernelExpressionVisitor::VisitDateLiteral(void *state, uintptr_t sibling_list_id, int32_t value) {
 	auto expression = make_uniq<ConstantExpression>(Value::DATE(static_cast<date_t>(value)));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitStringLiteral(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice value) {
+void KernelExpressionVisitor::VisitStringLiteral(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice value) {
 	auto expression = make_uniq<ConstantExpression>(Value(string(value.ptr, value.len)));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitBinaryLiteral(void *state, uintptr_t sibling_list_id, const uint8_t *buffer,
+void KernelExpressionVisitor::VisitBinaryLiteral(void *state, uintptr_t sibling_list_id, const uint8_t *buffer,
                                            uintptr_t len) {
 	auto expression = make_uniq<ConstantExpression>(Value::BLOB(buffer, len));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitNullLiteral(void *state, uintptr_t sibling_list_id, uint8_t type_tag, uint8_t precision,
+void KernelExpressionVisitor::VisitNullLiteral(void *state, uintptr_t sibling_list_id, uint8_t type_tag, uint8_t precision,
                                          uint8_t scale) {
 	// type_tag/precision/scale identify the kernel-side data type of the null; we don't need it
 	// since DuckDB's untyped NULL constant is cast to the correct type by the surrounding context.
 	auto expression = make_uniq<ConstantExpression>(Value());
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void ExpressionVisitor::VisitArrayLiteral(void *state, uintptr_t sibling_list_id, uintptr_t child_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitArrayLiteral(void *state, uintptr_t sibling_list_id, uintptr_t child_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	auto children = state_cast->TakeFieldList(child_id);
 	if (!children) {
 		return;
@@ -277,9 +277,9 @@ void ExpressionVisitor::VisitArrayLiteral(void *state, uintptr_t sibling_list_id
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitStructLiteral(void *state, uintptr_t sibling_list_id, uintptr_t child_field_list_value,
+void KernelExpressionVisitor::VisitStructLiteral(void *state, uintptr_t sibling_list_id, uintptr_t child_field_list_value,
                                            uintptr_t child_value_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto children_keys = state_cast->TakeFieldList(child_field_list_value);
 	auto children_values = state_cast->TakeFieldList(child_value_list_id);
@@ -289,7 +289,7 @@ void ExpressionVisitor::VisitStructLiteral(void *state, uintptr_t sibling_list_i
 
 	if (children_values->size() != children_keys->size()) {
 		state_cast->error =
-		    ErrorData("Size of Keys and Values vector do not match in ExpressionVisitor::VisitStructLiteral");
+		    ErrorData("Size of Keys and Values vector do not match in KernelExpressionVisitor::VisitStructLiteral");
 		return;
 	}
 
@@ -301,8 +301,8 @@ void ExpressionVisitor::VisitStructLiteral(void *state, uintptr_t sibling_list_i
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitNotExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitNotExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
 		return;
@@ -312,8 +312,8 @@ void ExpressionVisitor::VisitNotExpression(void *state, uintptr_t sibling_list_i
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitIsNullExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitIsNullExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
 		return;
@@ -325,9 +325,9 @@ void ExpressionVisitor::VisitIsNullExpression(void *state, uintptr_t sibling_lis
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitLiteralMap(void *state, uintptr_t sibling_list_id, uintptr_t key_list_id,
+void KernelExpressionVisitor::VisitLiteralMap(void *state, uintptr_t sibling_list_id, uintptr_t key_list_id,
                                         uintptr_t value_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto key_children = state_cast->TakeFieldList(key_list_id);
 	if (!key_children) {
@@ -367,9 +367,9 @@ void ExpressionVisitor::VisitLiteralMap(void *state, uintptr_t sibling_list_id, 
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitOpaqueExpression(void *data, uintptr_t sibling_list_id,
+void KernelExpressionVisitor::VisitOpaqueExpression(void *data, uintptr_t sibling_list_id,
                                               ffi::Handle<ffi::SharedOpaqueExpressionOp> op, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(data);
+	auto state_cast = static_cast<KernelExpressionVisitor *>(data);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
 		return;
@@ -381,9 +381,9 @@ void ExpressionVisitor::VisitOpaqueExpression(void *data, uintptr_t sibling_list
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitOpaquePredicate(void *data, uintptr_t sibling_list_id,
+void KernelExpressionVisitor::VisitOpaquePredicate(void *data, uintptr_t sibling_list_id,
                                              ffi::Handle<ffi::SharedOpaquePredicateOp> op, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(data);
+	auto state_cast = static_cast<KernelExpressionVisitor *>(data);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
 		return;
@@ -395,8 +395,8 @@ void ExpressionVisitor::VisitOpaquePredicate(void *data, uintptr_t sibling_list_
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitUnknown(void *data, uintptr_t sibling_list_id, ffi::KernelStringSlice name) {
-	auto state_cast = static_cast<ExpressionVisitor *>(data);
+void KernelExpressionVisitor::VisitUnknown(void *data, uintptr_t sibling_list_id, ffi::KernelStringSlice name) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(data);
 	vector<unique_ptr<ParsedExpression>> children;
 	// TODO:
 	// auto name_str = KernelUtils::FromDeltaString(name);
@@ -407,13 +407,13 @@ void ExpressionVisitor::VisitUnknown(void *data, uintptr_t sibling_list_id, ffi:
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitParseJsonExpression(void *data, uintptr_t sibling_list_id, uintptr_t child_list_id,
+void KernelExpressionVisitor::VisitParseJsonExpression(void *data, uintptr_t sibling_list_id, uintptr_t child_list_id,
                                                  ffi::Handle<ffi::SharedSchema> output_schema) {
-	auto state_cast = static_cast<ExpressionVisitor *>(data);
+	auto state_cast = static_cast<KernelExpressionVisitor *>(data);
 	state_cast->error = ErrorData(ExceptionType::NOT_IMPLEMENTED, "visit_parse_json not yet supported");
 }
 
-void ExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, int64_t value_ms, uint64_t value_ls,
+void KernelExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, int64_t value_ms, uint64_t value_ls,
                                             uint8_t precision, uint8_t scale) {
 	try {
 		Value decimal_value;
@@ -424,13 +424,13 @@ void ExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling_list_
 			decimal_value = Value::DECIMAL({value_ms, value_ls}, precision, scale);
 		}
 		auto expression = make_uniq<ConstantExpression>(decimal_value);
-		static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+		static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 	} catch (Exception &e) {
-		static_cast<ExpressionVisitor *>(state)->error = ErrorData(e);
+		static_cast<KernelExpressionVisitor *>(state)->error = ErrorData(e);
 	}
 }
 
-void ExpressionVisitor::VisitColumnExpression(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name) {
+void KernelExpressionVisitor::VisitColumnExpression(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name) {
 	auto col_ref_string = string(name.ptr, name.len);
 
 	// Delta ColRefs are sometimes backtick-ed
@@ -439,11 +439,11 @@ void ExpressionVisitor::VisitColumnExpression(void *state, uintptr_t sibling_lis
 	}
 
 	auto expression = make_uniq<ColumnRefExpression>(Identifier(col_ref_string));
-	static_cast<ExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
+	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitStructExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+void KernelExpressionVisitor::VisitStructExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto children_values = state_cast->TakeFieldList(child_list_id);
 	if (!children_values) {
@@ -454,7 +454,7 @@ void ExpressionVisitor::VisitStructExpression(void *state, uintptr_t sibling_lis
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-unique_ptr<ParsedExpression> ExpressionVisitor::MakeStructPatchOp(const string &kind, const string *field_name,
+unique_ptr<ParsedExpression> KernelExpressionVisitor::MakeStructPatchOp(const string &kind, const string *field_name,
                                                                   FieldList &&insertions, bool keep_input,
                                                                   bool optional) {
 	// Encode as "delta_transform_op(<insertion values...>, keep_input, optional, field_name, kind)".
@@ -487,10 +487,10 @@ unique_ptr<ParsedExpression> ExpressionVisitor::MakeStructPatchOp(const string &
 	return make_uniq<FunctionExpression>("delta_transform_op", std::move(children_values));
 }
 
-void ExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t sibling_list_id, uintptr_t input_path_list_id,
+void KernelExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t sibling_list_id, uintptr_t input_path_list_id,
                                                    uintptr_t prepended_field_list_id, uintptr_t field_patch_list_id,
                                                    uintptr_t appended_field_list_id) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto field_patches = state_cast->TakeFieldList(field_patch_list_id);
 	if (!field_patches) {
@@ -537,9 +537,9 @@ void ExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t siblin
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void ExpressionVisitor::VisitFieldPatch(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice field_name,
+void KernelExpressionVisitor::VisitFieldPatch(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice field_name,
                                         uintptr_t insertion_expr_list_id, bool keep_input, bool optional) {
-	auto state_cast = static_cast<ExpressionVisitor *>(state);
+	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	FieldList insertions;
 	if (insertion_expr_list_id) {
@@ -556,10 +556,10 @@ void ExpressionVisitor::VisitFieldPatch(void *state, uintptr_t sibling_list_id, 
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-uintptr_t ExpressionVisitor::MakeFieldList(ExpressionVisitor *state, uintptr_t capacity_hint) {
+uintptr_t KernelExpressionVisitor::MakeFieldList(KernelExpressionVisitor *state, uintptr_t capacity_hint) {
 	return state->MakeFieldListImpl(capacity_hint);
 }
-uintptr_t ExpressionVisitor::MakeFieldListImpl(uintptr_t capacity_hint) {
+uintptr_t KernelExpressionVisitor::MakeFieldListImpl(uintptr_t capacity_hint) {
 	uintptr_t id = next_id++;
 	auto list = make_uniq<FieldList>();
 	if (capacity_hint > 0) {
@@ -569,20 +569,20 @@ uintptr_t ExpressionVisitor::MakeFieldListImpl(uintptr_t capacity_hint) {
 	return id;
 }
 
-void ExpressionVisitor::AppendToList(uintptr_t id, unique_ptr<ParsedExpression> child) {
+void KernelExpressionVisitor::AppendToList(uintptr_t id, unique_ptr<ParsedExpression> child) {
 	auto it = inflight_lists.find(id);
 	if (it == inflight_lists.end()) {
-		error = ErrorData("ExpressionVisitor::AppendToList could not find " + Value::UBIGINT(id).ToString());
+		error = ErrorData("KernelExpressionVisitor::AppendToList could not find " + Value::UBIGINT(id).ToString());
 		return;
 	}
 
 	it->second->emplace_back(std::move(child));
 }
 
-unique_ptr<ExpressionVisitor::FieldList> ExpressionVisitor::TakeFieldList(uintptr_t id) {
+unique_ptr<KernelExpressionVisitor::FieldList> KernelExpressionVisitor::TakeFieldList(uintptr_t id) {
 	auto it = inflight_lists.find(id);
 	if (it == inflight_lists.end()) {
-		error = ErrorData("ExpressionVisitor::TakeFieldList could not find " + Value::UBIGINT(id).ToString());
+		error = ErrorData("KernelExpressionVisitor::TakeFieldList could not find " + Value::UBIGINT(id).ToString());
 		return nullptr;
 	}
 	auto rval = std::move(it->second);
@@ -590,7 +590,7 @@ unique_ptr<ExpressionVisitor::FieldList> ExpressionVisitor::TakeFieldList(uintpt
 	return rval;
 }
 
-ffi::EngineSchemaVisitor SchemaVisitor::CreateSchemaVisitor(SchemaVisitor &state) {
+ffi::EngineSchemaVisitor KernelSchemaVisitor::CreateSchemaVisitor(KernelSchemaVisitor &state) {
 	ffi::EngineSchemaVisitor visitor;
 
 	visitor.data = &state;
@@ -627,9 +627,9 @@ ffi::EngineSchemaVisitor SchemaVisitor::CreateSchemaVisitor(SchemaVisitor &state
 	return visitor;
 }
 
-vector<DeltaMultiFileColumnDefinition> SchemaVisitor::VisitSnapshotSchema(ffi::Handle<ffi::SharedExternEngine> engine,
-                                                                          ffi::SharedSnapshot *snapshot) {
-	SchemaVisitor state(engine);
+vector<DeltaMultiFileColumnDefinition> KernelSchemaVisitor::ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine,
+                                                                                ffi::SharedSnapshot *snapshot) {
+	KernelSchemaVisitor state(engine);
 	auto visitor = CreateSchemaVisitor(state);
 
 	auto schema = logical_schema(snapshot);
@@ -644,9 +644,9 @@ vector<DeltaMultiFileColumnDefinition> SchemaVisitor::VisitSnapshotSchema(ffi::H
 }
 
 vector<DeltaMultiFileColumnDefinition>
-SchemaVisitor::VisitSnapshotGlobalReadSchema(ffi::Handle<ffi::SharedExternEngine> engine, ffi::SharedScan *scan,
-                                             bool logical) {
-	SchemaVisitor visitor_state(engine);
+KernelSchemaVisitor::ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine, ffi::SharedScan *scan,
+                                         bool logical) {
+	KernelSchemaVisitor visitor_state(engine);
 	auto visitor = CreateSchemaVisitor(visitor_state);
 
 	ffi::Handle<ffi::SharedSchema> schema;
@@ -667,9 +667,9 @@ SchemaVisitor::VisitSnapshotGlobalReadSchema(ffi::Handle<ffi::SharedExternEngine
 }
 
 vector<DeltaMultiFileColumnDefinition>
-SchemaVisitor::VisitWriteContextSchema(ffi::Handle<ffi::SharedExternEngine> engine,
-                                       ffi::SharedWriteContext *write_context) {
-	SchemaVisitor visitor_state(engine);
+KernelSchemaVisitor::ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine,
+                                         ffi::SharedWriteContext *write_context) {
+	KernelSchemaVisitor visitor_state(engine);
 	auto visitor = CreateSchemaVisitor(visitor_state);
 	auto schema = ffi::get_write_schema(write_context);
 	uintptr_t result = visit_schema(schema, &visitor);
@@ -682,7 +682,7 @@ SchemaVisitor::VisitWriteContextSchema(ffi::Handle<ffi::SharedExternEngine> engi
 	return visitor_state.TakeFieldList(result);
 }
 
-void SchemaVisitor::VisitDecimal(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+void KernelSchemaVisitor::VisitDecimal(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
                                  bool is_nullable, const ffi::CStringMap *metadata, uint8_t precision, uint8_t scale) {
 	auto decimal_type = LogicalType::DECIMAL(precision, scale);
 	DeltaMultiFileColumnDefinition decimal_def(KernelUtils::FromDeltaString(name), decimal_type, is_nullable);
@@ -693,11 +693,11 @@ void SchemaVisitor::VisitDecimal(SchemaVisitor *state, uintptr_t sibling_list_id
 	state->AppendToList(sibling_list_id, name, std::move(decimal_def));
 }
 
-uintptr_t SchemaVisitor::MakeFieldList(SchemaVisitor *state, uintptr_t capacity_hint) {
+uintptr_t KernelSchemaVisitor::MakeFieldList(KernelSchemaVisitor *state, uintptr_t capacity_hint) {
 	return state->MakeFieldListImpl(capacity_hint);
 }
 
-void SchemaVisitor::VisitStruct(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+void KernelSchemaVisitor::VisitStruct(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
                                 bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id) {
 	auto children = state->TakeFieldList(child_list_id);
 
@@ -716,7 +716,7 @@ void SchemaVisitor::VisitStruct(SchemaVisitor *state, uintptr_t sibling_list_id,
 	state->AppendToList(sibling_list_id, name, std::move(struct_def));
 }
 
-void SchemaVisitor::VisitArray(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+void KernelSchemaVisitor::VisitArray(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
                                bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id) {
 	auto children = state->TakeFieldList(child_list_id);
 
@@ -736,7 +736,7 @@ void SchemaVisitor::VisitArray(SchemaVisitor *state, uintptr_t sibling_list_id, 
 	state->AppendToList(sibling_list_id, name, std::move(list_def));
 }
 
-void SchemaVisitor::VisitMap(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+void KernelSchemaVisitor::VisitMap(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
                              bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id) {
 	auto children = state->TakeFieldList(child_list_id);
 
@@ -759,7 +759,7 @@ void SchemaVisitor::VisitMap(SchemaVisitor *state, uintptr_t sibling_list_id, ff
 	state->AppendToList(sibling_list_id, name, std::move(map_def));
 }
 
-void SchemaVisitor::VisitVariant(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+void KernelSchemaVisitor::VisitVariant(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
                                  bool is_nullable, const ffi::CStringMap *metadata) {
 	// NOTE: logical type always VARIANT here, backwards compatible parsing from STRUCT(value, metadata) handled in
 	// parquet_read() via IsVariantType function, which is always enabled via the __delta_only_variant_encoding_enabled
@@ -770,7 +770,7 @@ void SchemaVisitor::VisitVariant(SchemaVisitor *state, uintptr_t sibling_list_id
 	state->AppendToList(sibling_list_id, name, std::move(col_def));
 }
 
-uintptr_t SchemaVisitor::MakeFieldListImpl(uintptr_t capacity_hint) {
+uintptr_t KernelSchemaVisitor::MakeFieldListImpl(uintptr_t capacity_hint) {
 	uintptr_t id = next_id++;
 	auto list = vector<DeltaMultiFileColumnDefinition>();
 	;
@@ -781,10 +781,10 @@ uintptr_t SchemaVisitor::MakeFieldListImpl(uintptr_t capacity_hint) {
 	return id;
 }
 
-void SchemaVisitor::AppendToList(uintptr_t id, ffi::KernelStringSlice name, DeltaMultiFileColumnDefinition &&child) {
+void KernelSchemaVisitor::AppendToList(uintptr_t id, ffi::KernelStringSlice name, DeltaMultiFileColumnDefinition &&child) {
 	auto it = inflight_lists.find(id);
 	if (it == inflight_lists.end()) {
-		error = ErrorData(ExceptionType::INTERNAL, "Unhandled error in SchemaVisitor::AppendToList");
+		error = ErrorData(ExceptionType::INTERNAL, "Unhandled error in KernelSchemaVisitor::AppendToList");
 		return;
 	}
 
@@ -794,10 +794,10 @@ void SchemaVisitor::AppendToList(uintptr_t id, ffi::KernelStringSlice name, Delt
 	it->second.emplace_back(std::move(child));
 }
 
-vector<DeltaMultiFileColumnDefinition> SchemaVisitor::TakeFieldList(uintptr_t id) {
+vector<DeltaMultiFileColumnDefinition> KernelSchemaVisitor::TakeFieldList(uintptr_t id) {
 	auto it = inflight_lists.find(id);
 	if (it == inflight_lists.end()) {
-		error = ErrorData(ExceptionType::INTERNAL, "Unhandled error in SchemaVisitor::TakeFieldList");
+		error = ErrorData(ExceptionType::INTERNAL, "Unhandled error in KernelSchemaVisitor::TakeFieldList");
 		return vector<DeltaMultiFileColumnDefinition>();
 	}
 	auto rval = std::move(it->second);

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -30,7 +30,8 @@
 
 namespace duckdb {
 
-void KernelExpressionVisitor::VisitComparisonExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+void KernelExpressionVisitor::VisitComparisonExpression(void *state, uintptr_t sibling_list_id,
+                                                        uintptr_t child_list_id) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto children = state_cast->TakeFieldList(child_list_id);
@@ -169,7 +170,8 @@ void KernelExpressionVisitor::VisitAdditionExpression(void *state, uintptr_t sib
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void KernelExpressionVisitor::VisitSubtractionExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
+void KernelExpressionVisitor::VisitSubtractionExpression(void *state, uintptr_t sibling_list_id,
+                                                         uintptr_t child_list_id) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
@@ -256,12 +258,12 @@ void KernelExpressionVisitor::VisitStringLiteral(void *state, uintptr_t sibling_
 	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
 void KernelExpressionVisitor::VisitBinaryLiteral(void *state, uintptr_t sibling_list_id, const uint8_t *buffer,
-                                           uintptr_t len) {
+                                                 uintptr_t len) {
 	auto expression = make_uniq<ConstantExpression>(Value::BLOB(buffer, len));
 	static_cast<KernelExpressionVisitor *>(state)->AppendToList(sibling_list_id, std::move(expression));
 }
-void KernelExpressionVisitor::VisitNullLiteral(void *state, uintptr_t sibling_list_id, uint8_t type_tag, uint8_t precision,
-                                         uint8_t scale) {
+void KernelExpressionVisitor::VisitNullLiteral(void *state, uintptr_t sibling_list_id, uint8_t type_tag,
+                                               uint8_t precision, uint8_t scale) {
 	// type_tag/precision/scale identify the kernel-side data type of the null; we don't need it
 	// since DuckDB's untyped NULL constant is cast to the correct type by the surrounding context.
 	auto expression = make_uniq<ConstantExpression>(Value());
@@ -277,8 +279,8 @@ void KernelExpressionVisitor::VisitArrayLiteral(void *state, uintptr_t sibling_l
 	state_cast->AppendToList(sibling_list_id, std::move(expression));
 }
 
-void KernelExpressionVisitor::VisitStructLiteral(void *state, uintptr_t sibling_list_id, uintptr_t child_field_list_value,
-                                           uintptr_t child_value_list_id) {
+void KernelExpressionVisitor::VisitStructLiteral(void *state, uintptr_t sibling_list_id,
+                                                 uintptr_t child_field_list_value, uintptr_t child_value_list_id) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto children_keys = state_cast->TakeFieldList(child_field_list_value);
@@ -326,7 +328,7 @@ void KernelExpressionVisitor::VisitIsNullExpression(void *state, uintptr_t sibli
 }
 
 void KernelExpressionVisitor::VisitLiteralMap(void *state, uintptr_t sibling_list_id, uintptr_t key_list_id,
-                                        uintptr_t value_list_id) {
+                                              uintptr_t value_list_id) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto key_children = state_cast->TakeFieldList(key_list_id);
@@ -368,7 +370,8 @@ void KernelExpressionVisitor::VisitLiteralMap(void *state, uintptr_t sibling_lis
 }
 
 void KernelExpressionVisitor::VisitOpaqueExpression(void *data, uintptr_t sibling_list_id,
-                                              ffi::Handle<ffi::SharedOpaqueExpressionOp> op, uintptr_t child_list_id) {
+                                                    ffi::Handle<ffi::SharedOpaqueExpressionOp> op,
+                                                    uintptr_t child_list_id) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(data);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
@@ -382,7 +385,8 @@ void KernelExpressionVisitor::VisitOpaqueExpression(void *data, uintptr_t siblin
 }
 
 void KernelExpressionVisitor::VisitOpaquePredicate(void *data, uintptr_t sibling_list_id,
-                                             ffi::Handle<ffi::SharedOpaquePredicateOp> op, uintptr_t child_list_id) {
+                                                   ffi::Handle<ffi::SharedOpaquePredicateOp> op,
+                                                   uintptr_t child_list_id) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(data);
 	auto children = state_cast->TakeFieldList(child_list_id);
 	if (!children) {
@@ -408,13 +412,13 @@ void KernelExpressionVisitor::VisitUnknown(void *data, uintptr_t sibling_list_id
 }
 
 void KernelExpressionVisitor::VisitParseJsonExpression(void *data, uintptr_t sibling_list_id, uintptr_t child_list_id,
-                                                 ffi::Handle<ffi::SharedSchema> output_schema) {
+                                                       ffi::Handle<ffi::SharedSchema> output_schema) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(data);
 	state_cast->error = ErrorData(ExceptionType::NOT_IMPLEMENTED, "visit_parse_json not yet supported");
 }
 
-void KernelExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, int64_t value_ms, uint64_t value_ls,
-                                            uint8_t precision, uint8_t scale) {
+void KernelExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling_list_id, int64_t value_ms,
+                                                  uint64_t value_ls, uint8_t precision, uint8_t scale) {
 	try {
 		Value decimal_value;
 		if (precision < Decimal::MAX_WIDTH_INT64) {
@@ -430,7 +434,8 @@ void KernelExpressionVisitor::VisitDecimalLiteral(void *state, uintptr_t sibling
 	}
 }
 
-void KernelExpressionVisitor::VisitColumnExpression(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name) {
+void KernelExpressionVisitor::VisitColumnExpression(void *state, uintptr_t sibling_list_id,
+                                                    ffi::KernelStringSlice name) {
 	auto col_ref_string = string(name.ptr, name.len);
 
 	// Delta ColRefs are sometimes backtick-ed
@@ -455,8 +460,8 @@ void KernelExpressionVisitor::VisitStructExpression(void *state, uintptr_t sibli
 }
 
 unique_ptr<ParsedExpression> KernelExpressionVisitor::MakeStructPatchOp(const string &kind, const string *field_name,
-                                                                  FieldList &&insertions, bool keep_input,
-                                                                  bool optional) {
+                                                                        FieldList &&insertions, bool keep_input,
+                                                                        bool optional) {
 	// Encode as "delta_transform_op(<insertion values...>, keep_input, optional, field_name, kind)".
 	// `kind` is one of "prepend"/"field"/"append" and disambiguates the unnamed prepend/append
 	// patches (position-only, no field_name/keep_input/optional semantics) from named field
@@ -487,9 +492,11 @@ unique_ptr<ParsedExpression> KernelExpressionVisitor::MakeStructPatchOp(const st
 	return make_uniq<FunctionExpression>("delta_transform_op", std::move(children_values));
 }
 
-void KernelExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t sibling_list_id, uintptr_t input_path_list_id,
-                                                   uintptr_t prepended_field_list_id, uintptr_t field_patch_list_id,
-                                                   uintptr_t appended_field_list_id) {
+void KernelExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t sibling_list_id,
+                                                         uintptr_t input_path_list_id,
+                                                         uintptr_t prepended_field_list_id,
+                                                         uintptr_t field_patch_list_id,
+                                                         uintptr_t appended_field_list_id) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	auto field_patches = state_cast->TakeFieldList(field_patch_list_id);
@@ -538,7 +545,7 @@ void KernelExpressionVisitor::VisitStructPatchExpression(void *state, uintptr_t 
 }
 
 void KernelExpressionVisitor::VisitFieldPatch(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice field_name,
-                                        uintptr_t insertion_expr_list_id, bool keep_input, bool optional) {
+                                              uintptr_t insertion_expr_list_id, bool keep_input, bool optional) {
 	auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 
 	FieldList insertions;
@@ -627,8 +634,8 @@ ffi::EngineSchemaVisitor KernelSchemaVisitor::CreateSchemaVisitor(KernelSchemaVi
 	return visitor;
 }
 
-vector<DeltaMultiFileColumnDefinition> KernelSchemaVisitor::ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine,
-                                                                                ffi::SharedSnapshot *snapshot) {
+vector<DeltaMultiFileColumnDefinition>
+KernelSchemaVisitor::ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine, ffi::SharedSnapshot *snapshot) {
 	KernelSchemaVisitor state(engine);
 	auto visitor = CreateSchemaVisitor(state);
 
@@ -682,8 +689,9 @@ KernelSchemaVisitor::ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> en
 	return visitor_state.TakeFieldList(result);
 }
 
-void KernelSchemaVisitor::VisitDecimal(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
-                                 bool is_nullable, const ffi::CStringMap *metadata, uint8_t precision, uint8_t scale) {
+void KernelSchemaVisitor::VisitDecimal(KernelSchemaVisitor *state, uintptr_t sibling_list_id,
+                                       ffi::KernelStringSlice name, bool is_nullable, const ffi::CStringMap *metadata,
+                                       uint8_t precision, uint8_t scale) {
 	auto decimal_type = LogicalType::DECIMAL(precision, scale);
 	DeltaMultiFileColumnDefinition decimal_def(KernelUtils::FromDeltaString(name), decimal_type, is_nullable);
 	decimal_def.default_expression = make_uniq<ConstantExpression>(Value().DefaultCastAs(decimal_type));
@@ -697,8 +705,9 @@ uintptr_t KernelSchemaVisitor::MakeFieldList(KernelSchemaVisitor *state, uintptr
 	return state->MakeFieldListImpl(capacity_hint);
 }
 
-void KernelSchemaVisitor::VisitStruct(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
-                                bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id) {
+void KernelSchemaVisitor::VisitStruct(KernelSchemaVisitor *state, uintptr_t sibling_list_id,
+                                      ffi::KernelStringSlice name, bool is_nullable, const ffi::CStringMap *metadata,
+                                      uintptr_t child_list_id) {
 	auto children = state->TakeFieldList(child_list_id);
 
 	child_list_t<LogicalType> children_types;
@@ -717,7 +726,7 @@ void KernelSchemaVisitor::VisitStruct(KernelSchemaVisitor *state, uintptr_t sibl
 }
 
 void KernelSchemaVisitor::VisitArray(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
-                               bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id) {
+                                     bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id) {
 	auto children = state->TakeFieldList(child_list_id);
 
 	D_ASSERT(children.size() == 1);
@@ -737,7 +746,7 @@ void KernelSchemaVisitor::VisitArray(KernelSchemaVisitor *state, uintptr_t sibli
 }
 
 void KernelSchemaVisitor::VisitMap(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
-                             bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id) {
+                                   bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id) {
 	auto children = state->TakeFieldList(child_list_id);
 
 	D_ASSERT(children.size() == 2);
@@ -759,8 +768,8 @@ void KernelSchemaVisitor::VisitMap(KernelSchemaVisitor *state, uintptr_t sibling
 	state->AppendToList(sibling_list_id, name, std::move(map_def));
 }
 
-void KernelSchemaVisitor::VisitVariant(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
-                                 bool is_nullable, const ffi::CStringMap *metadata) {
+void KernelSchemaVisitor::VisitVariant(KernelSchemaVisitor *state, uintptr_t sibling_list_id,
+                                       ffi::KernelStringSlice name, bool is_nullable, const ffi::CStringMap *metadata) {
 	// NOTE: logical type always VARIANT here, backwards compatible parsing from STRUCT(value, metadata) handled in
 	// parquet_read() via IsVariantType function, which is always enabled via the __delta_only_variant_encoding_enabled
 	// global setting.
@@ -781,7 +790,8 @@ uintptr_t KernelSchemaVisitor::MakeFieldListImpl(uintptr_t capacity_hint) {
 	return id;
 }
 
-void KernelSchemaVisitor::AppendToList(uintptr_t id, ffi::KernelStringSlice name, DeltaMultiFileColumnDefinition &&child) {
+void KernelSchemaVisitor::AppendToList(uintptr_t id, ffi::KernelStringSlice name,
+                                       DeltaMultiFileColumnDefinition &&child) {
 	auto it = inflight_lists.find(id);
 	if (it == inflight_lists.end()) {
 		error = ErrorData(ExceptionType::INTERNAL, "Unhandled error in KernelSchemaVisitor::AppendToList");

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -363,8 +363,13 @@ static unordered_map<idx_t, Value> FindPartitionValues(ParsedExpression &transfo
 			                  child.GetExpression().Cast<FunctionExpression>().FunctionName());
 		}
 
-		bool is_replace = false;
+		// kind: "prepend" | "field" | "append" (see MakeStructPatchOp in delta_utils.cpp).
+		// keep_input/optional only apply to kind == "field".
+		string kind;
+		bool keep_input = false;
+		bool optional = false;
 		string field_name;
+		bool has_field_name = false;
 		vector<Value> values;
 
 		for (auto &transform_op_child : transform_op.GetArguments()) {
@@ -380,11 +385,16 @@ static unordered_map<idx_t, Value> FindPartitionValues(ParsedExpression &transfo
 				                 .Cast<ConstantExpression>()
 				                 .GetValue();
 
-				if (name == "is_replace") {
-					is_replace = value.GetValue<bool>();
+				if (name == "kind") {
+					kind = value.ToString();
+				} else if (name == "keep_input") {
+					keep_input = value.GetValue<bool>();
+				} else if (name == "optional") {
+					optional = value.GetValue<bool>();
 				} else if (name == "field_name") {
 					if (!value.IsNull()) {
 						field_name = value.ToString();
+						has_field_name = true;
 					}
 				} else {
 					throw InternalException("Unexpected name for delta_transform_op returned by delta kernel: %s",
@@ -399,21 +409,27 @@ static unordered_map<idx_t, Value> FindPartitionValues(ParsedExpression &transfo
 			}
 		}
 
-		/// NOTE: Treating list id 0 as an empty list yields a simplified truth table:
-		///
-		/// |field_name? |is_replace? |meaning|
+		/// |kind    |keep_input? |meaning|
 		/// |-|-|-|
-		/// | NO  | *   | Prepend a (possibly empty) list of expressions to the output
-		/// | YES | NO  | Insert a (possibly empty)  list of expressions after the named input field
-		/// | YES | YES | Replace the named input field with a (possibly empty) list of expressions
+		/// |prepend |   *        | Prepend a (possibly empty) list of expressions to the output
+		/// |append  |   *        | Append a (possibly empty) list of expressions to the output
+		/// |field   |  YES       | Insert a (possibly empty) list of expressions after the named input field
+		/// |field   |  NO        | Replace the named input field with a (possibly empty) list of expressions
 		// TODO: broken for multiple transform expressions?
 		idx_t index_to_insert = 0;
-		if (!field_name.empty()) {
+		if (kind == "append") {
+			index_to_insert = cols.size();
+		} else if (kind == "field" && has_field_name) {
+			bool found = false;
 			for (idx_t i = 0; i < cols.size(); ++i) {
 				if (field_name == cols[i].name) {
-					index_to_insert = is_replace ? i : i + 1;
+					index_to_insert = keep_input ? i + 1 : i;
+					found = true;
 					break;
 				}
+			}
+			if (!found && optional) {
+				continue;
 			}
 		}
 

--- a/src/functions/delta_scan/delta_multi_file_list.cpp
+++ b/src/functions/delta_scan/delta_multi_file_list.cpp
@@ -488,8 +488,7 @@ void ScanDataCallBack::VisitCallbackInternal(ffi::NullableCvoid engine_context, 
 
 	// Lookup all columns for potential hits in the constant map
 	if (transform) {
-		ExpressionVisitor visitor;
-		auto parsed_transformation_expression = visitor.VisitKernelExpression(transform);
+		auto parsed_transformation_expression = KernelExpressionVisitor::ToParsedExpression(transform);
 
 		if (!parsed_transformation_expression) {
 			context->error = ErrorData(ExceptionType::IO,
@@ -645,7 +644,7 @@ void DeltaMultiFileList::Bind(vector<LogicalType> &return_types, vector<Identifi
 	vector<DeltaMultiFileColumnDefinition> visited_schema;
 	{
 		auto snapshot_ref = snapshot->GetLockingRef();
-		visited_schema = SchemaVisitor::VisitSnapshotSchema(extern_engine.get(), snapshot_ref.GetPtr());
+		visited_schema = KernelSchemaVisitor::ToColumnDefinitions(extern_engine.get(), snapshot_ref.GetPtr());
 	}
 
 	for (const auto &field : visited_schema) {
@@ -819,7 +818,7 @@ void DeltaMultiFileList::InitializeScan() const {
 		}
 	}
 
-	lazy_loaded_schema = SchemaVisitor::VisitSnapshotGlobalReadSchema(extern_engine.get(), scan.get(), true);
+	lazy_loaded_schema = KernelSchemaVisitor::ToColumnDefinitions(extern_engine.get(), scan.get(), true);
 
 	DeltaMultiFileColumnDefinition::Print(lazy_loaded_schema, "lazy_loaded_schema");
 

--- a/src/functions/expression_functions.cpp
+++ b/src/functions/expression_functions.cpp
@@ -32,13 +32,11 @@ static void GetDeltaTestExpression(DataChunk &input, ExpressionState &state, Vec
 	vector<Value> result_to_string;
 
 	auto kernel_testing_expr = ffi::get_testing_kernel_expression();
-	ExpressionVisitor visitor;
-	auto parsed_expressions = visitor.VisitKernelExpression(&kernel_testing_expr);
+	auto parsed_expressions = KernelExpressionVisitor::ToParsedExpression(&kernel_testing_expr);
 	AddTestExpressions(result_to_string, *parsed_expressions);
 
 	auto kernel_testing_pred = ffi::get_testing_kernel_predicate();
-	ExpressionVisitor visitor_pred;
-	auto parsed_pred = visitor_pred.VisitKernelPredicate(&kernel_testing_pred);
+	auto parsed_pred = KernelExpressionVisitor::ToParsedExpression(&kernel_testing_pred);
 	AddTestExpressions(result_to_string, *parsed_pred);
 
 	output.SetValue(0, Value::LIST(result_to_string));

--- a/src/include/delta_utils.hpp
+++ b/src/include/delta_utils.hpp
@@ -139,7 +139,8 @@ private:
 	static void VisitDateLiteral(void *state, uintptr_t sibling_list_id, int32_t value);
 	static void VisitStringLiteral(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice value);
 	static void VisitBinaryLiteral(void *state, uintptr_t sibling_list_id, const uint8_t *buffer, uintptr_t len);
-	static void VisitNullLiteral(void *state, uintptr_t sibling_list_id);
+	static void VisitNullLiteral(void *state, uintptr_t sibling_list_id, uint8_t type_tag, uint8_t precision,
+	                             uint8_t scale);
 	static void VisitArrayLiteral(void *state, uintptr_t sibling_list_id, uintptr_t child_id);
 	static void VisitStructLiteral(void *data, uintptr_t sibling_list_id, uintptr_t child_field_list_value,
 	                               uintptr_t child_value_list_id);
@@ -147,10 +148,13 @@ private:
 	                                uint8_t precision, uint8_t scale);
 	static void VisitColumnExpression(void *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name);
 	static void VisitStructExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id);
-	static void VisitTransformExpression(void *data, uintptr_t sibling_list_id, uintptr_t input_path_list_id,
-	                                     uintptr_t child_list_id);
-	static void VisitFieldTransform(void *data, uintptr_t sibling_list_id, const ffi::KernelStringSlice *field_name,
-	                                uintptr_t expr_list_id, bool is_replace);
+	static void VisitStructPatchExpression(void *data, uintptr_t sibling_list_id, uintptr_t input_path_list_id,
+	                                       uintptr_t prepended_field_list_id, uintptr_t field_patch_list_id,
+	                                       uintptr_t appended_field_list_id);
+	static void VisitFieldPatch(void *data, uintptr_t sibling_list_id, ffi::KernelStringSlice field_name,
+	                            uintptr_t insertion_expr_list_id, bool keep_input, bool optional);
+	static unique_ptr<ParsedExpression> MakeStructPatchOp(const string &kind, const string *field_name,
+	                                                      FieldList &&insertions, bool keep_input, bool optional);
 	static void VisitNotExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id);
 	static void VisitIsNullExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id);
 	static void VisitLiteralMap(void *data, uintptr_t sibling_list_id, uintptr_t key_list_id, uintptr_t value_list_id);

--- a/src/include/delta_utils.hpp
+++ b/src/include/delta_utils.hpp
@@ -284,8 +284,8 @@ public:
 
 	static vector<DeltaMultiFileColumnDefinition> ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine,
 	                                                                  ffi::SharedSnapshot *snapshot);
-	static vector<DeltaMultiFileColumnDefinition>
-	ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine, ffi::SharedScan *state, bool logical);
+	static vector<DeltaMultiFileColumnDefinition> ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine,
+	                                                                  ffi::SharedScan *state, bool logical);
 	static vector<DeltaMultiFileColumnDefinition> ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine,
 	                                                                  ffi::SharedWriteContext *write_context);
 
@@ -334,8 +334,8 @@ private:
 	                        bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id);
 	static void VisitArray(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
 	                       bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id);
-	static void VisitMap(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name, bool is_nullable,
-	                     const ffi::CStringMap *metadata, uintptr_t child_list_id);
+	static void VisitMap(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+	                     bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id);
 	static void VisitVariant(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
 	                         bool is_nullable, const ffi::CStringMap *metadata);
 

--- a/src/include/delta_utils.hpp
+++ b/src/include/delta_utils.hpp
@@ -96,16 +96,16 @@ struct KernelUtils {
 	UnpackTransformExpression(const vector<unique_ptr<ParsedExpression>> &parsed_expression);
 };
 
-class ExpressionVisitor : public ffi::EngineExpressionVisitor {
+class KernelExpressionVisitor : public ffi::EngineExpressionVisitor {
 	using FieldList = vector<unique_ptr<ParsedExpression>>;
 
 public:
-	unique_ptr<vector<unique_ptr<ParsedExpression>>>
-	VisitKernelExpression(const ffi::Handle<ffi::SharedExpression> *expression);
-	unique_ptr<vector<unique_ptr<ParsedExpression>>>
-	VisitKernelPredicate(const ffi::Handle<ffi::SharedPredicate> *predicate);
-	unique_ptr<vector<unique_ptr<ParsedExpression>>> VisitKernelExpression(const ffi::Expression *expression);
-	ffi::EngineExpressionVisitor CreateVisitor(ExpressionVisitor &state);
+	static unique_ptr<vector<unique_ptr<ParsedExpression>>>
+	ToParsedExpression(const ffi::Handle<ffi::SharedExpression> *expression);
+	static unique_ptr<vector<unique_ptr<ParsedExpression>>>
+	ToParsedExpression(const ffi::Handle<ffi::SharedPredicate> *predicate);
+	static unique_ptr<vector<unique_ptr<ParsedExpression>>> ToParsedExpression(const ffi::Expression *expression);
+	static ffi::EngineExpressionVisitor CreateVisitor(KernelExpressionVisitor &state);
 
 private:
 	unordered_map<uintptr_t, unique_ptr<FieldList>> inflight_lists;
@@ -120,7 +120,7 @@ private:
 	}
 	template <typename CPP_TYPE, typename CREATE_VALUE_FUN>
 	static void VisitPrimitiveLiteral(void *state, uintptr_t sibling_list_id, CPP_TYPE value) {
-		auto state_cast = static_cast<ExpressionVisitor *>(state);
+		auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 		auto duckdb_value = CREATE_VALUE_FUN(value);
 		auto expression = make_uniq<ConstantExpression>(duckdb_value);
 		state_cast->AppendToList(sibling_list_id, std::move(expression));
@@ -181,7 +181,7 @@ private:
 
 	template <ExpressionType EXPRESSION_TYPE, typename EXPRESSION_TYPENAME>
 	static void VisitVariadicExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-		auto state_cast = static_cast<ExpressionVisitor *>(state);
+		auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 		auto children = state_cast->TakeFieldList(child_list_id);
 		if (!children) {
 			state_cast->AppendToList(sibling_list_id, std::move(make_uniq<ConstantExpression>(Value(42))));
@@ -199,7 +199,7 @@ private:
 
 	template <ExpressionType EXPRESSION_TYPE, typename EXPRESSION_TYPENAME>
 	static void VisitBinaryExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id) {
-		auto state_cast = static_cast<ExpressionVisitor *>(state);
+		auto state_cast = static_cast<KernelExpressionVisitor *>(state);
 		auto children = state_cast->TakeFieldList(child_list_id);
 		if (!children) {
 			state_cast->AppendToList(sibling_list_id, std::move(make_uniq<ConstantExpression>(Value(42))));
@@ -223,7 +223,7 @@ private:
 	static void VisitComparisonExpression(void *state, uintptr_t sibling_list_id, uintptr_t child_list_id);
 
 	// List functions
-	static uintptr_t MakeFieldList(ExpressionVisitor *state, uintptr_t capacity_hint);
+	static uintptr_t MakeFieldList(KernelExpressionVisitor *state, uintptr_t capacity_hint);
 	void AppendToList(uintptr_t id, unique_ptr<ParsedExpression> child);
 	uintptr_t MakeFieldListImpl(uintptr_t capacity_hint);
 	unique_ptr<FieldList> TakeFieldList(uintptr_t id);
@@ -277,17 +277,17 @@ struct DeltaMultiFileColumnDefinition : public MultiFileColumnDefinition {
 	bool nullable = true;
 };
 
-// SchemaVisitor is used to parse the schema of a Delta table from the Kernel
-class SchemaVisitor {
+// KernelSchemaVisitor is used to parse the schema of a Delta table from the Kernel
+class KernelSchemaVisitor {
 public:
-	explicit SchemaVisitor(ffi::Handle<ffi::SharedExternEngine> engine_p) : engine(engine_p) {};
+	explicit KernelSchemaVisitor(ffi::Handle<ffi::SharedExternEngine> engine_p) : engine(engine_p) {};
 
-	static vector<DeltaMultiFileColumnDefinition> VisitSnapshotSchema(ffi::Handle<ffi::SharedExternEngine> engine,
+	static vector<DeltaMultiFileColumnDefinition> ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine,
 	                                                                  ffi::SharedSnapshot *snapshot);
 	static vector<DeltaMultiFileColumnDefinition>
-	VisitSnapshotGlobalReadSchema(ffi::Handle<ffi::SharedExternEngine> engine, ffi::SharedScan *state, bool logical);
-	static vector<DeltaMultiFileColumnDefinition> VisitWriteContextSchema(ffi::Handle<ffi::SharedExternEngine> engine,
-	                                                                      ffi::SharedWriteContext *write_context);
+	ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine, ffi::SharedScan *state, bool logical);
+	static vector<DeltaMultiFileColumnDefinition> ToColumnDefinitions(ffi::Handle<ffi::SharedExternEngine> engine,
+	                                                                  ffi::SharedWriteContext *write_context);
 
 private:
 	unordered_map<uintptr_t, vector<DeltaMultiFileColumnDefinition>> inflight_lists;
@@ -296,7 +296,7 @@ private:
 	ffi::SharedExternEngine *engine = nullptr;
 	ErrorData error;
 
-	static ffi::EngineSchemaVisitor CreateSchemaVisitor(SchemaVisitor &state);
+	static ffi::EngineSchemaVisitor CreateSchemaVisitor(KernelSchemaVisitor &state);
 
 	typedef void(SimpleTypeVisitorFunction)(void *, uintptr_t, ffi::KernelStringSlice, bool is_nullable,
 	                                        const ffi::CStringMap *metadata);
@@ -319,7 +319,7 @@ private:
 		return (SimpleTypeVisitorFunction *)&VisitSimpleTypeImpl<TypeId>;
 	}
 	template <LogicalTypeId TypeId>
-	static void VisitSimpleTypeImpl(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+	static void VisitSimpleTypeImpl(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
 	                                bool is_nullable, const ffi::CStringMap *metadata) {
 		DeltaMultiFileColumnDefinition col_def(KernelUtils::FromDeltaString(name), TypeId, is_nullable);
 		ApplyDeltaColumnMapping(state->engine, metadata, col_def);
@@ -327,16 +327,16 @@ private:
 		state->AppendToList(sibling_list_id, name, std::move(col_def));
 	}
 
-	static void VisitDecimal(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+	static void VisitDecimal(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
 	                         bool is_nullable, const ffi::CStringMap *metadata, uint8_t precision, uint8_t scale);
-	static uintptr_t MakeFieldList(SchemaVisitor *state, uintptr_t capacity_hint);
-	static void VisitStruct(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+	static uintptr_t MakeFieldList(KernelSchemaVisitor *state, uintptr_t capacity_hint);
+	static void VisitStruct(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
 	                        bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id);
-	static void VisitArray(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+	static void VisitArray(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
 	                       bool is_nullable, const ffi::CStringMap *metadata, uintptr_t child_list_id);
-	static void VisitMap(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name, bool is_nullable,
+	static void VisitMap(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name, bool is_nullable,
 	                     const ffi::CStringMap *metadata, uintptr_t child_list_id);
-	static void VisitVariant(SchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
+	static void VisitVariant(KernelSchemaVisitor *state, uintptr_t sibling_list_id, ffi::KernelStringSlice name,
 	                         bool is_nullable, const ffi::CStringMap *metadata);
 
 	uintptr_t MakeFieldListImpl(uintptr_t capacity_hint);

--- a/src/storage/delta_transaction.cpp
+++ b/src/storage/delta_transaction.cpp
@@ -303,7 +303,8 @@ vector<DeltaMultiFileColumnDefinition> DeltaTransaction::GetWriteSchema(ClientCo
 		InitializeTransaction(context);
 	}
 
-	auto write_context = ffi::get_write_context(kernel_transaction.get());
+	auto write_context = write_entry.get()->snapshot->TryUnpackKernelResult(ffi::get_unpartitioned_write_context(
+	    kernel_transaction.get(), write_entry.get()->snapshot->extern_engine.get()));
 	auto result =
 	    SchemaVisitor::VisitWriteContextSchema(write_entry.get()->snapshot->extern_engine.get(), write_context);
 	return result;
@@ -469,7 +470,7 @@ void DeltaTransaction::Commit(ClientContext &context) {
 
 			// We have some special error handling here to ensure the error created by DuckDB is properly thrown here,
 			// because we can't throw it across the FFI boundary, we need to store it in the transaction
-			uint64_t commit_result;
+			ffi::Handle<ffi::ExclusiveCommittedTransaction> commit_result;
 
 			DUCKDB_LOG_INTERNAL(context, "delta.Commit", LogLevel::LOG_DEBUG, "Committing %s",
 			                    table_entry->snapshot->GetPath());
@@ -481,6 +482,8 @@ void DeltaTransaction::Commit(ClientContext &context) {
 				} else {
 					res.Throw();
 				}
+			} else {
+				ffi::free_committed_transaction(commit_result);
 			}
 		}
 	}

--- a/src/storage/delta_transaction.cpp
+++ b/src/storage/delta_transaction.cpp
@@ -307,6 +307,7 @@ vector<DeltaMultiFileColumnDefinition> DeltaTransaction::GetWriteSchema(ClientCo
 	    kernel_transaction.get(), write_entry.get()->snapshot->extern_engine.get()));
 	auto result =
 	    SchemaVisitor::VisitWriteContextSchema(write_entry.get()->snapshot->extern_engine.get(), write_context);
+	ffi::free_write_context(write_context);
 	return result;
 }
 

--- a/src/storage/delta_transaction.cpp
+++ b/src/storage/delta_transaction.cpp
@@ -306,7 +306,7 @@ vector<DeltaMultiFileColumnDefinition> DeltaTransaction::GetWriteSchema(ClientCo
 	auto write_context = write_entry.get()->snapshot->TryUnpackKernelResult(ffi::get_unpartitioned_write_context(
 	    kernel_transaction.get(), write_entry.get()->snapshot->extern_engine.get()));
 	auto result =
-	    SchemaVisitor::VisitWriteContextSchema(write_entry.get()->snapshot->extern_engine.get(), write_context);
+	    KernelSchemaVisitor::ToColumnDefinitions(write_entry.get()->snapshot->extern_engine.get(), write_context);
 	ffi::free_write_context(write_context);
 	return result;
 }

--- a/src/storage/delta_transaction_manager.cpp
+++ b/src/storage/delta_transaction_manager.cpp
@@ -69,8 +69,15 @@ void DeltaTransactionManager::Checkpoint(ClientContext &context, bool force) {
 	// Get a locking ref to the shared ffi snapshot
 	auto snapshot_ref = table_entry.snapshot->snapshot->GetLockingRef();
 
-	table_entry.snapshot->TryUnpackKernelResult(
-	    ffi::checkpoint_snapshot(snapshot_ref.GetPtr(), table_entry.snapshot->extern_engine.get()));
+	auto checkpoint_result = table_entry.snapshot->TryUnpackKernelResult(
+	    ffi::checkpoint_snapshot(snapshot_ref.GetPtr(), table_entry.snapshot->extern_engine.get(), nullptr));
+	// Both result variants carry an owned snapshot handle (the pre-existing or newly-written
+	// snapshot) that we don't need here, but must still release.
+	if (checkpoint_result.tag == ffi::FfiCheckpointWriteResult::Tag::FfiCheckpointWriteResultWritten) {
+		ffi::free_snapshot(checkpoint_result.written._0);
+	} else {
+		ffi::free_snapshot(checkpoint_result.already_exists._0);
+	}
 }
 
 } // namespace duckdb

--- a/test/sql/generated/delta_list_files.test
+++ b/test/sql/generated/delta_list_files.test
@@ -25,8 +25,8 @@ SELECT data_file[-8:], cardinality, partitions, have_deletes FROM delta_list_fil
 query IIIII
 SELECT data_file[-8:], cardinality, partitions, have_deletes, transform_expression FROM delta_list_files('./data/generated/simple_partitioned/delta_lake', transform_expression=1) order by partitions;
 ----
-.parquet	5	{part=0}	false	['delta_kernel_transform_expression(delta_transform_op(0, (is_replace = false), (field_name = \'i\')))']
-.parquet	5	{part=1}	false	['delta_kernel_transform_expression(delta_transform_op(1, (is_replace = false), (field_name = \'i\')))']
+.parquet	5	{part=0}	false	['delta_kernel_transform_expression(delta_transform_op(0, (keep_input = true), (optional = false), (field_name = \'i\'), (kind = \'field\')))']
+.parquet	5	{part=1}	false	['delta_kernel_transform_expression(delta_transform_op(1, (keep_input = true), (optional = false), (field_name = \'i\'), (kind = \'field\')))']
 
 query IIIII
 SELECT data_file[-8:], cardinality, partitions, have_deletes, delete_count FROM delta_list_files('./data/generated/simple_partitioned/delta_lake', delete_count=1) order by partitions;

--- a/test/sql/generated/file_skipping_all_types.test
+++ b/test/sql/generated/file_skipping_all_types.test
@@ -40,21 +40,6 @@ analyzed_plan	<REGEX>:.* Scanning Files: 4/5.*
 
 endloop
 
-# use bool column to skip files
-query II
-EXPLAIN ANALYZE SELECT *
-FROM delta_scan('./data/generated/test_file_skipping/bool/delta_lake')
-WHERE value1=false
-----
-analyzed_plan	<REGEX>:.*File Filters:.*value1 = false.*Scanning Files: 1/2.*
-
-query II
-EXPLAIN ANALYZE SELECT part
-FROM delta_scan('./data/generated/test_file_skipping/bool/delta_lake')
-WHERE part=false
-----
-analyzed_plan	<REGEX>:.* Scanning Files: 1/2.*
-
 foreach type int tinyint smallint bigint
 
 # using <type> column to skip files

--- a/test/sql/generated/writing/append/write_stats_primitives.test
+++ b/test/sql/generated/writing/append/write_stats_primitives.test
@@ -181,41 +181,6 @@ statement ok
 DETACH t;
 
 #------------------------------------------------------------------------------
-# Bool
-# Existing data: 2 files (one all-false, one all-true); insert all-true row
-# After insert: 3 files; WHERE value1=false skips the 2 true files → 1/3
-#------------------------------------------------------------------------------
-
-statement ok
-from copy_dir('data/generated/test_file_skipping/bool', '{TEMP_DIR}/write_stats_all_types/bool');
-
-statement ok
-ATTACH '{TEMP_DIR}/write_stats_all_types/bool/delta_lake' AS t (TYPE delta);
-
-statement ok
-INSERT INTO t (value1, value2, value3, part) VALUES (true, true, true, true);
-
-query IIIII
-SELECT
-    json_extract_string(add.stats, '$.numRecords'),
-    json_extract_string(add.stats, '$.nullCount.value1'),
-    json_extract_string(add.stats, '$.minValues.value1'),
-    json_extract_string(add.stats, '$.maxValues.value1'),
-    json_extract_string(add.stats, '$.tightBounds')
-FROM read_json('{TEMP_DIR}/write_stats_all_types/bool/delta_lake/_delta_log/00000000000000000001.json')
-WHERE add IS NOT NULL
-----
-1	0	true	true	true
-
-query II
-EXPLAIN ANALYZE SELECT value1 FROM t WHERE value1 = false
-----
-analyzed_plan	<REGEX>:.*Scanning Files: 1/3.*
-
-statement ok
-DETACH t;
-
-#------------------------------------------------------------------------------
 # Decimal
 # Existing data: 5 files with values 1.00–5.00; insert 6.00
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Bumps delta-kernel-rs from v0.21.0 to v0.26.0, adapt to the API changes that came with it.

  - rework struct-patch expressions: Kernel reworked its tranform-expression FFI into a struct-patch model; ported the visitor side and filled out some missing visit types (void,array)
  - fix FFI header generation fix: update `extern` to `extern "C"` to correctly match declarations
  - fix checkpoint/commit/write-context handle lifetime handling: checkpoint_snapshot, commit, and
  get_unpartitioned_write_context all changed to return owned handles that must be explicitly freed; wired up
  the missing frees on each
  - drop boolean-column data-skipping test coverage: delta-kernel-rs stopped pruning files by boolean min/max
  stats as of this bump (confirmed intentional, spec-compliant kernel change, not a bug)
  - rename the kernel-facing expression/schema visitors: ExpressionVisitor/SchemaVisitor read inconsistently, rename/cast as converters from delta-kernel -> duckdb types (and disambiguate from similar-but-different neighbors)

