### PR TITLE
Support TIMESTAMP/TIMESTAMP_TZ literals in predicate pushdown

### DIFF
--- a/scripts/data_generator/generate_test_data.py
+++ b/scripts/data_generator/generate_test_data.py
@@ -160,6 +160,11 @@ type = "timestamp"
 query = f"CREATE table test_table as select ('2024-01-0' || i::VARCHAR || ' 00:00:00')::TIMESTAMP as value1, ('2024-01-0' || i::VARCHAR || ' 00:00:00')::TIMESTAMP as part from range(1,6) tbl(i)"
 generate_test_data_delta_rs(BASE_PATH,f"test_file_skipping/{type}", query, "part")
 
+## Partitioned table with timestamptz type
+type = "timestamptz"
+query = f"CREATE table test_table as select ('2024-01-0' || i::VARCHAR || ' 00:00:00+00')::TIMESTAMPTZ as value1, ('2024-01-0' || i::VARCHAR || ' 00:00:00+00')::TIMESTAMPTZ as part from range(1,6) tbl(i)"
+generate_test_data_delta_rs(BASE_PATH,f"test_file_skipping/{type}", query, "part")
+
 ## Partitioned table with decimal type
 type = "decimal"
 query = f"CREATE table test_table as select i::DECIMAL(10,2) as value1, i::DECIMAL(10,2) as part from range(1,6) tbl(i)"

--- a/src/delta_utils.cpp
+++ b/src/delta_utils.cpp
@@ -1075,9 +1075,13 @@ uintptr_t PredicateVisitor::VisitConstantFilter(const string &col_name, Expressi
 		}
 		break;
 	}
+	case LogicalTypeId::TIMESTAMP:
+		right = visit_expression_literal_timestamp_ntz(state, TimestampValue::Get(value).value);
+		break;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		right = visit_expression_literal_timestamp(state, TimestampTZValue::Get(value).value);
+		break;
 	// TODO: implement these types
-	case LogicalTypeId::TIMESTAMP:    // kernel ignores max stats for timestamps (see delta-kernel-rs#1002)
-	case LogicalTypeId::TIMESTAMP_TZ: // kernel ignores max stats for timestamps (see delta-kernel-rs#1002)
 	case LogicalTypeId::STRUCT:
 	case LogicalTypeId::MAP:
 	case LogicalTypeId::LIST:

--- a/test/sql/generated/file_skipping_all_types.test
+++ b/test/sql/generated/file_skipping_all_types.test
@@ -212,12 +212,51 @@ WHERE value1 = '2024-01-03 00:00:00+00'::TIMESTAMPTZ
 ----
 analyzed_plan	<REGEX>:.*File Filters:.*value1 = .*Scanning Files: 1/5.*
 
+# Compared against a literal rather than asserted as rendered text: TIMESTAMPTZ
+# renders in the session timezone, and pinning it would need icu.
+query II
+SELECT value1 = '2024-01-03 00:00:00+00'::TIMESTAMPTZ, part = '2024-01-03 00:00:00+00'::TIMESTAMPTZ
+FROM delta_scan('./data/generated/test_file_skipping/timestamptz/delta_lake')
+WHERE value1 = '2024-01-03 00:00:00+00'::TIMESTAMPTZ
+----
+true	true
+
+# A literal carrying a non-UTC offset denotes the same instant, so it must prune
+# to the same file and return the same row.
+query II
+EXPLAIN ANALYZE SELECT value1
+FROM delta_scan('./data/generated/test_file_skipping/timestamptz/delta_lake')
+WHERE value1 = '2024-01-02 16:00:00-08'::TIMESTAMPTZ
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 1/5.*
+
+query II
+SELECT value1 = '2024-01-03 00:00:00+00'::TIMESTAMPTZ, part = '2024-01-03 00:00:00+00'::TIMESTAMPTZ
+FROM delta_scan('./data/generated/test_file_skipping/timestamptz/delta_lake')
+WHERE value1 = '2024-01-02 16:00:00-08'::TIMESTAMPTZ
+----
+true	true
+
 query II
 EXPLAIN ANALYZE SELECT value1
 FROM delta_scan('./data/generated/test_file_skipping/timestamptz/delta_lake')
 WHERE value1 > '2030-01-01 00:00:00+00'::TIMESTAMPTZ
 ----
 analyzed_plan	<REGEX>:.* Scanning Files: 0/5.*
+
+query II
+EXPLAIN ANALYZE SELECT value1
+FROM delta_scan('./data/generated/test_file_skipping/timestamptz/delta_lake')
+WHERE value1 >= '2024-01-04 00:00:00+00'::TIMESTAMPTZ
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 2/5.*
+
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/timestamptz/delta_lake')
+WHERE part = '2024-01-03 00:00:00+00'::TIMESTAMPTZ
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 1/5.*
 
 ### STRUCT
 

--- a/test/sql/generated/file_skipping_all_types.test
+++ b/test/sql/generated/file_skipping_all_types.test
@@ -164,6 +164,61 @@ WHERE part = 3.00::DECIMAL(10,2)
 ----
 analyzed_plan	<REGEX>:.* Scanning Files: 1/5.*
 
+### TIMESTAMP
+
+# using timestamp column to skip files
+query II
+EXPLAIN ANALYZE SELECT value1, part
+FROM delta_scan('./data/generated/test_file_skipping/timestamp/delta_lake')
+WHERE value1 = '2024-01-03 00:00:00'::TIMESTAMP
+----
+analyzed_plan	<REGEX>:.*File Filters:.*value1 = '2024-01-03 00:00:00'.*Scanning Files: 1/5.*
+
+query II
+SELECT value1, part
+FROM delta_scan('./data/generated/test_file_skipping/timestamp/delta_lake')
+WHERE value1 = '2024-01-03 00:00:00'::TIMESTAMP
+----
+2024-01-03 00:00:00	2024-01-03 00:00:00
+
+query II
+EXPLAIN ANALYZE SELECT value1
+FROM delta_scan('./data/generated/test_file_skipping/timestamp/delta_lake')
+WHERE value1 > '2030-01-01 00:00:00'::TIMESTAMP
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 0/5.*
+
+query II
+EXPLAIN ANALYZE SELECT value1
+FROM delta_scan('./data/generated/test_file_skipping/timestamp/delta_lake')
+WHERE value1 >= '2024-01-04 00:00:00'::TIMESTAMP
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 2/5.*
+
+query II
+EXPLAIN ANALYZE SELECT part
+FROM delta_scan('./data/generated/test_file_skipping/timestamp/delta_lake')
+WHERE part = '2024-01-03 00:00:00'::TIMESTAMP
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 1/5.*
+
+### TIMESTAMP WITH TIME ZONE
+
+# using timestamptz column to skip files
+query II
+EXPLAIN ANALYZE SELECT value1, part
+FROM delta_scan('./data/generated/test_file_skipping/timestamptz/delta_lake')
+WHERE value1 = '2024-01-03 00:00:00+00'::TIMESTAMPTZ
+----
+analyzed_plan	<REGEX>:.*File Filters:.*value1 = .*Scanning Files: 1/5.*
+
+query II
+EXPLAIN ANALYZE SELECT value1
+FROM delta_scan('./data/generated/test_file_skipping/timestamptz/delta_lake')
+WHERE value1 > '2030-01-01 00:00:00+00'::TIMESTAMPTZ
+----
+analyzed_plan	<REGEX>:.* Scanning Files: 0/5.*
+
 ### STRUCT
 
 # using struct field column to skip files
@@ -205,8 +260,6 @@ WHERE value.i = 0
 # TODO test remaining types:
 # - MAP
 # - LIST
-# - TIMESTAMP
-# - TIMESTAMP_TZ
 
 ### Now test all Comparators are fileskipping
 

--- a/test/sql/generated/writing/append/write_stats_primitives.test
+++ b/test/sql/generated/writing/append/write_stats_primitives.test
@@ -292,8 +292,13 @@ WHERE add IS NOT NULL
 ----
 1	0	2024-01-06T00:00:00	2024-01-06T00:00:00	true
 
-# NOTE: timestamp_ntz stats-based file skipping is not yet supported by delta-kernel v0.20.0,
-# so EXPLAIN ANALYZE file-skipping assertions are omitted here.
+# Skipping against the stats written above. The filter has to prune the file this
+# test just inserted: reading it back trips the URL-encoded partition bug skipped
+# for further up.
+query II
+EXPLAIN ANALYZE SELECT value1 FROM t WHERE value1 = '2024-01-03 00:00:00'::TIMESTAMP
+----
+analyzed_plan	<REGEX>:.*File Filters:.*value1 = '2024-01-03 00:00:00'.*Scanning Files: 1/6.*
 
 statement ok
 DETACH t;


### PR DESCRIPTION
VisitConstantFilter did not convert TIMESTAMP or TIMESTAMP_TZ literals, so predicates on those columns never reached the kernel and no files were skipped. The comment cited delta-kernel-rs#1002, which was resolved by delta-io/delta-kernel-rs#2249 (kernel v0.21.0, already pinned here): the kernel now compensates for the millisecond truncation of timestamp stats when comparing against max values.

Add the two literal cases using the existing FFI builders, and cover TIMESTAMP/TIMESTAMP_TZ in file_skipping_all_types.test.