### PR TITLE
fix: report an unknown schema instead of returning nothing

### DIFF
--- a/src/storage/delta_catalog.cpp
+++ b/src/storage/delta_catalog.cpp
@@ -108,10 +108,16 @@ optional_ptr<SchemaCatalogEntry> DeltaCatalog::LookupSchema(CatalogTransaction t
 	if (schema_name == DEFAULT_SCHEMA || schema_name == INVALID_SCHEMA) {
 		return main_schema.get();
 	}
-	if (if_not_found == OnEntryNotFound::RETURN_NULL) {
+	switch (if_not_found) {
+	case OnEntryNotFound::RETURN_NULL:
 		return nullptr;
+	case OnEntryNotFound::THROW_EXCEPTION:
+		throw CatalogException(schema_lookup.GetErrorContext(),
+		                       "Schema \"%s\" does not exist! A delta catalog holds one table, under \"%s\"",
+		                       schema_name, DEFAULT_SCHEMA);
+	default:
+		throw InternalException("Unknown OnEntryNotFound value %d", static_cast<int>(if_not_found));
 	}
-	return nullptr;
 }
 
 bool DeltaCatalog::InMemory() {

--- a/test/sql/main/schema_lookup.test
+++ b/test/sql/main/schema_lookup.test
@@ -1,0 +1,43 @@
+# name: test/sql/main/schema_lookup.test
+# description: An unknown schema on a delta catalog is a catalog error, not an internal one
+# group: [main]
+
+require parquet
+
+require delta
+
+statement ok
+FROM copy_dir('data/inlined/simple_table', '{TEMP_DIR}/main/schema_lookup');
+
+statement ok
+ATTACH '{TEMP_DIR}/main/schema_lookup/delta_lake' AS t (TYPE delta);
+
+# -----------------------------------------------------------------------------
+# The one schema a delta catalog has
+#
+
+statement ok
+SELECT * FROM t.main.t LIMIT 1;
+
+# -----------------------------------------------------------------------------
+# Any other name, where the caller wants an exception
+#
+# It dereferences what the lookup returns, so answering with an unset optional crashes the engine
+# instead of naming the schema.
+#
+
+statement error
+CREATE TABLE t.other_schema.x (i INT);
+----
+Catalog Error: Schema "other_schema" does not exist!
+
+# -----------------------------------------------------------------------------
+# Any other name, where the caller wants a null
+#
+# Same lookup, other branch: the binder builds its own message and must keep getting the chance to.
+#
+
+statement error
+SELECT * FROM t.other_schema.t;
+----
+Catalog Error: Table with name "other_schema.t" does not exist


### PR DESCRIPTION
Correct handling when a LookupSchema call found nothing. Was always returning nullptr, instead of honoring
the given disposition, and throwing a catalog exception. Unnoticed except in e.g. Unity Catalog / time travel
cases. Throwing allows DuckDB to surface the intended error correctly.