### PR TITLE
fix: match/pin duckdb from v2.0-cyanoptera branch

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       # Main config
       extension_name: &ext_name delta
-      duckdb_version: &duckdb_ref main
+      duckdb_version: &duckdb_ref 816a3eb2d512ce359efb40d9319f6db59788422a # v2.0-cyanoptera 2026-09-08 pin
       ci_tools_version: &ci_tools_ref main
       enable_rust: true
       exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools;windows_amd64_mingw;linux_amd64_musl"

--- a/src/include/storage/delta_table_entry.hpp
+++ b/src/include/storage/delta_table_entry.hpp
@@ -31,6 +31,8 @@ public:
 
 	TableStorageInfo GetStorageInfo(ClientContext &context) override;
 
+	const ColumnList &GetColumns() const override;
+
 	void BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj, LogicalUpdate &update,
 	                           ClientContext &context) override;
 
@@ -39,6 +41,7 @@ public:
 
 public:
 	shared_ptr<DeltaMultiFileList> snapshot;
+	ColumnList columns; // copied from CreateTableInfo
 
 protected:
 	TableFunction GetScanFunctionInternal(ClientContext &context, unique_ptr<FunctionData> &bind_data,

--- a/src/storage/delta_table_entry.cpp
+++ b/src/storage/delta_table_entry.cpp
@@ -15,8 +15,12 @@
 namespace duckdb {
 
 DeltaTableEntry::DeltaTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info)
-    : TableCatalogEntry(catalog, schema, info) {
+    : TableCatalogEntry(catalog, schema, info), columns(info.columns.Copy()) {
 	this->internal = false;
+}
+
+const ColumnList &DeltaTableEntry::GetColumns() const {
+	return columns;
 }
 
 DeltaTableEntry::~DeltaTableEntry() = default;


### PR DESCRIPTION
Core stopped keeping a ColumnList in TableCatalogEntry and made GetColumns() pure virtual; Copy out of the CreateTableInfo instead of move so that we own it.