### PR TITLE
fix: Allow an INSERT to span several partitions

### DIFF
--- a/src/storage/delta_insert.cpp
+++ b/src/storage/delta_insert.cpp
@@ -255,11 +255,7 @@ static void AddWrittenFiles(DeltaInsertGlobalState &global_state, DataChunk &chu
 SinkResultType DeltaInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
 	auto &global_state = input.global_state.Cast<DeltaInsertGlobalState>();
 
-	if (chunk.size() != 1) {
-		throw InternalException(
-		    "DeltaInsert::Sink expects a single row containing output of the PhysicalCopy that should be its Source");
-	}
-
+	// The PhysicalCopyToFile reports one row per file written, so a partitioned write arrives as several.
 	AddWrittenFiles(global_state, chunk);
 
 	return SinkResultType::NEED_MORE_INPUT;

--- a/test/sql/generated/writing/append/write_multi_partition.test
+++ b/test/sql/generated/writing/append/write_multi_partition.test
@@ -1,0 +1,117 @@
+# name: test/sql/generated/writing/append/write_multi_partition.test
+# description: an append spanning several partitions must commit every file it writes
+# group: [append]
+
+# https://github.com/duckdb/duckdb-delta/issues/334
+
+require parquet
+
+require delta
+
+require json
+
+require-env GENERATED_DATA_AVAILABLE
+
+statement ok
+from copy_dir('data/generated/simple_partitioned', '{TEMP_DIR}/write_multi_partition/simple_partitioned');
+
+statement ok
+ATTACH '{TEMP_DIR}/write_multi_partition/simple_partitioned/delta_lake' AS t (TYPE delta);
+
+# -----------------------------------------------------------------------------
+# Baseline
+#
+
+query II
+SELECT count(*), sum(i) FROM t;
+----
+10	45
+
+query II
+SELECT part, count(*) FROM t GROUP BY part ORDER BY part;
+----
+0	5
+1	5
+
+# -----------------------------------------------------------------------------
+# One statement, two partitions
+#
+
+# The reported count must cover every file, not just the first one.
+query I
+INSERT INTO t SELECT i, i%2 AS part FROM range(100,106) tbl(i);
+----
+6
+
+query II
+SELECT count(*), sum(i) FROM t;
+----
+16	660
+
+query II
+SELECT part, count(*) FROM t GROUP BY part ORDER BY part;
+----
+0	8
+1	8
+
+# Both partitions are recorded in the one commit. Counting distinct partition
+# values rather than add entries, since a partition may be split over files.
+query I
+SELECT count(DISTINCT json_extract_string(add.partitionValues, '$.part'))
+FROM read_json('{TEMP_DIR}/write_multi_partition/simple_partitioned/delta_lake/_delta_log/00000000000000000001.json')
+WHERE add IS NOT NULL;
+----
+2
+
+# The rows are accounted for by the stats of the committed files, so no file was
+# written to disk but left out of the log.
+query I
+SELECT sum(json_extract(add.stats, '$.numRecords')::BIGINT)
+FROM read_json('{TEMP_DIR}/write_multi_partition/simple_partitioned/delta_lake/_delta_log/00000000000000000001.json')
+WHERE add IS NOT NULL;
+----
+6
+
+# -----------------------------------------------------------------------------
+# More partitions than the table started with
+#
+
+query I
+INSERT INTO t SELECT i, i AS part FROM range(200,204) tbl(i);
+----
+4
+
+query I
+SELECT count(DISTINCT json_extract_string(add.partitionValues, '$.part'))
+FROM read_json('{TEMP_DIR}/write_multi_partition/simple_partitioned/delta_lake/_delta_log/00000000000000000002.json')
+WHERE add IS NOT NULL;
+----
+4
+
+query II
+SELECT count(*), sum(i) FROM t;
+----
+20	1466
+
+# -----------------------------------------------------------------------------
+# Re-read from the log
+#
+
+statement ok
+DETACH t;
+
+statement ok
+ATTACH '{TEMP_DIR}/write_multi_partition/simple_partitioned/delta_lake' AS t (TYPE delta);
+
+query II
+SELECT count(*), sum(i) FROM t;
+----
+20	1466
+
+query II
+SELECT part, count(*) FROM t WHERE part >= 200 GROUP BY part ORDER BY part;
+----
+200	1
+201	1
+202	1
+203	1


### PR DESCRIPTION
Allow an INSERT to span several partitions

Multi-partition-spanning writes were explicitly blocked off and rejected; there
is no reason to do so. Thus, remove the block and allow it! And test it too.

Fixes https://github.com/duckdb/duckdb-delta/issues/334